### PR TITLE
Add Anchors sin IA plugin implementation

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1,0 +1,183 @@
+#sai-app {
+    margin-top: 20px;
+}
+
+.sai-search {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    padding: 20px;
+    border-radius: 4px;
+}
+
+.sai-search-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: flex-end;
+}
+
+.sai-label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 600;
+}
+
+.sai-label input {
+    margin-top: 6px;
+    min-width: 280px;
+    padding: 6px 8px;
+}
+
+.sai-search-actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.sai-checkbox {
+    display: flex;
+    align-items: center;
+    font-weight: 500;
+}
+
+.sai-checkbox input {
+    margin-right: 6px;
+}
+
+.sai-results {
+    margin-top: 20px;
+    display: grid;
+    gap: 12px;
+}
+
+.sai-result {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    background: #f9f9f9;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.sai-result-info h3 {
+    margin: 0 0 6px;
+    font-size: 16px;
+}
+
+.sai-result-meta {
+    margin: 0;
+    color: #555d66;
+    font-size: 13px;
+}
+
+.sai-result-actions .button {
+    margin-left: 6px;
+}
+
+.sai-status {
+    margin: 16px 0;
+    color: #555d66;
+}
+
+.sai-pagination {
+    margin-top: 16px;
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.sai-pagination span {
+    font-weight: 600;
+}
+
+.sai-detail {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    padding: 20px;
+    border-radius: 4px;
+}
+
+.sai-detail-header {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.sai-detail-columns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    margin-top: 16px;
+}
+
+.sai-detail-left {
+    flex: 1 1 240px;
+    background: #f6f7f7;
+    border: 1px solid #dcdcde;
+    padding: 16px;
+    border-radius: 4px;
+}
+
+.sai-detail-left p {
+    margin: 0 0 12px;
+}
+
+.sai-detail-right {
+    flex: 2 1 420px;
+}
+
+.sai-body-text {
+    width: 100%;
+    min-height: 240px;
+    resize: vertical;
+    margin: 12px 0;
+}
+
+.sai-table-wrapper {
+    margin-top: 16px;
+    max-height: 320px;
+    overflow: auto;
+}
+
+.sai-notice {
+    margin: 16px 0;
+    padding: 12px 16px;
+    border-left: 4px solid;
+    border-radius: 3px;
+}
+
+.sai-notice-success {
+    background: #f0f6f0;
+    border-color: #46b450;
+    color: #205522;
+}
+
+.sai-notice-error {
+    background: #fbeaea;
+    border-color: #dc3232;
+    color: #8a1f1f;
+}
+
+@media (max-width: 782px) {
+    .sai-search-actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .sai-result {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .sai-result-actions .button {
+        margin-left: 0;
+        margin-right: 6px;
+    }
+
+    .sai-detail-header {
+        justify-content: flex-start;
+        margin-bottom: 12px;
+    }
+}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,0 +1,443 @@
+(function () {
+    'use strict';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var settings = window.AnchorsSinIA || {};
+        var app = document.getElementById('sai-app');
+        if (!app || !settings.restUrl) {
+            return;
+        }
+
+        var state = {
+            keyword: '',
+            includeBody: false,
+            loading: false,
+            results: [],
+            total: 0,
+            totalPages: 0,
+            currentPage: 1,
+            hasSearched: false,
+            selectedPost: null,
+            postDetail: null,
+            anchors: [],
+            quotas: null,
+            notice: '',
+            noticeType: 'success',
+            canonical: '',
+            extracting: false
+        };
+
+        var i18n = settings.i18n || {};
+
+        function updateState(updates) {
+            for (var key in updates) {
+                if (Object.prototype.hasOwnProperty.call(updates, key)) {
+                    state[key] = updates[key];
+                }
+            }
+            render();
+        }
+
+        function getPreset(wordCount) {
+            if (wordCount <= 700) {
+                return { total: 4, exacta: 1, frase: 1, semantica: 2 };
+            }
+            if (wordCount <= 1500) {
+                return { total: 6, exacta: 1, frase: 3, semantica: 2 };
+            }
+            return { total: 8, exacta: 1, frase: 4, semantica: 3 };
+        }
+
+        function renderNotice() {
+            if (!state.notice) {
+                return '';
+            }
+            var typeClass = state.noticeType === 'error' ? 'sai-notice-error' : 'sai-notice-success';
+            return '<div class="sai-notice ' + typeClass + '">' + escapeHtml(state.notice) + '</div>';
+        }
+
+        function escapeHtml(text) {
+            if (!text && text !== 0) {
+                return '';
+            }
+            return String(text)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        function renderSearch() {
+            var html = '';
+            html += '<div class="sai-search">';
+            html += '<div class="sai-search-controls">';
+            html += '<label class="sai-label">' + escapeHtml(i18n.keywordLabel || 'Palabra clave (canónico)') +
+                '<input type="text" id="sai-keyword" value="' + escapeHtml(state.keyword) + '" placeholder="' + escapeHtml(i18n.keywordLabel || '') + '"></label>';
+            html += '<div class="sai-search-actions">';
+            html += '<label class="sai-checkbox"><input type="checkbox" id="sai-in-body" ' + (state.includeBody ? 'checked' : '') + '> ' + escapeHtml(i18n.includeBody || '') + '</label>';
+            html += '<button type="button" id="sai-search-btn" class="button button-primary">' + escapeHtml(i18n.search || 'Buscar') + '</button>';
+            html += '</div></div>';
+            html += renderNotice();
+            html += '<div id="sai-results" class="sai-results">';
+
+            if (state.loading) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+            } else if (state.hasSearched && state.results.length === 0) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.noResults || 'Sin resultados.') + '</p>';
+            } else {
+                for (var i = 0; i < state.results.length; i++) {
+                    var item = state.results[i];
+                    html += '<div class="sai-result">';
+                    html += '<div class="sai-result-info">';
+                    html += '<h3>' + escapeHtml(item.title) + '</h3>';
+                    html += '<p class="sai-result-meta">' + escapeHtml(item.type) + '</p>';
+                    html += '</div>';
+                    html += '<div class="sai-result-actions">';
+                    html += '<a class="button" href="' + escapeHtml(item.link) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(i18n.view || 'Ver') + '</a>';
+                    html += '<button type="button" class="button button-primary" data-action="select" data-id="' + item.id + '">' + escapeHtml(i18n.select || 'Seleccionar') + '</button>';
+                    html += '</div>';
+                    html += '</div>';
+                }
+            }
+
+            html += '</div>';
+
+            if (state.totalPages > 1) {
+                html += '<div class="sai-pagination">';
+                html += '<button type="button" class="button" id="sai-prev" ' + (state.currentPage <= 1 ? 'disabled' : '') + '>&laquo;</button>';
+                html += '<span>' + escapeHtml((i18n.pageLabel || 'Página') + ' ' + state.currentPage + ' / ' + state.totalPages) + '</span>';
+                html += '<button type="button" class="button" id="sai-next" ' + (state.currentPage >= state.totalPages ? 'disabled' : '') + '>&raquo;</button>';
+                html += '</div>';
+            }
+
+            html += '</div>';
+
+            app.innerHTML = html;
+            bindSearchEvents();
+        }
+
+        function renderDetail() {
+            var preset = getPreset(state.postDetail && state.postDetail.word_count ? state.postDetail.word_count : 0);
+            var html = '';
+            html += '<div class="sai-detail">';
+            html += '<div class="sai-detail-header">';
+            html += '<button type="button" class="button" id="sai-back">' + escapeHtml(i18n.back || 'Volver a la búsqueda') + '</button>';
+            html += '</div>';
+            html += renderNotice();
+            if (!state.postDetail) {
+                if (!state.notice) {
+                    html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+                }
+                html += '</div>';
+                app.innerHTML = html;
+                bindDetailEvents();
+                return;
+            }
+            html += '<div class="sai-detail-columns">';
+            html += '<div class="sai-detail-left">';
+            html += '<p><strong>' + escapeHtml(i18n.keywordLabel || 'Palabra clave (canónico)') + ':</strong> ' + escapeHtml(state.canonical) + '</p>';
+            html += '<p><strong>' + escapeHtml(i18n.wordCount || 'Palabras') + ':</strong> ' + (state.postDetail.word_count || 0) + '</p>';
+            html += '<p><strong>' + escapeHtml(i18n.preset || 'Preset') + ':</strong> ' + preset.total + ' (Exacta ' + preset.exacta + ' / Frase ' + preset.frase + ' / Semántica ' + preset.semantica + ')</p>';
+            if (state.quotas) {
+                html += '<p><strong>' + escapeHtml(i18n.usedQuotas || 'Cuotas usadas') + ':</strong> ' + state.quotas.total + ' (Exacta ' + state.quotas.exacta + ' / Frase ' + state.quotas.frase + ' / Semántica ' + state.quotas.semantica + ')</p>';
+            }
+            html += '</div>';
+            html += '<div class="sai-detail-right">';
+            html += '<h2>' + escapeHtml((state.postDetail && state.postDetail.title) || (state.selectedPost && state.selectedPost.title) || '') + '</h2>';
+            html += '<textarea readonly class="sai-body-text" id="sai-body-text">' + escapeHtml(state.postDetail.body_text || '') + '</textarea>';
+            html += '<button type="button" class="button button-primary" id="sai-extract" ' + (state.extracting ? 'disabled' : '') + '>' + escapeHtml(state.extracting ? (i18n.extracting || 'Extrayendo...') : (i18n.extractAnchors || 'Extraer anchors')) + '</button>';
+            if (state.extracting) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+            }
+            if (state.anchors && state.anchors.length > 0) {
+                html += '<div class="sai-table-wrapper">';
+                html += '<table class="widefat fixed">';
+                html += '<thead><tr><th>' + escapeHtml((i18n.tableHeader && i18n.tableHeader[0]) || 'Anchor') + '</th><th>' + escapeHtml((i18n.tableHeader && i18n.tableHeader[1]) || 'Clasificación') + '</th><th>' + escapeHtml((i18n.tableHeader && i18n.tableHeader[2]) || 'Frecuencia') + '</th></tr></thead>';
+                html += '<tbody>';
+                for (var i = 0; i < state.anchors.length; i++) {
+                    var anchor = state.anchors[i];
+                    html += '<tr><td>' + escapeHtml(anchor.text) + '</td><td>' + escapeHtml(anchor.class) + '</td><td>' + escapeHtml(anchor.frequency) + '</td></tr>';
+                }
+                html += '</tbody></table>';
+                html += '</div>';
+                html += '<button type="button" class="button" id="sai-copy">' + escapeHtml(i18n.copyAnchors || 'Copiar anchors') + '</button>';
+            } else if (!state.extracting && state.quotas) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.noAnchors || 'No hay anchors disponibles.') + '</p>';
+            }
+            html += '</div>';
+            html += '</div>';
+            html += '</div>';
+
+            app.innerHTML = html;
+            bindDetailEvents();
+        }
+
+        function render() {
+            if (state.selectedPost) {
+                renderDetail();
+            } else {
+                renderSearch();
+            }
+        }
+
+        function bindSearchEvents() {
+            var keywordInput = document.getElementById('sai-keyword');
+            var searchBtn = document.getElementById('sai-search-btn');
+            var inBodyCheckbox = document.getElementById('sai-in-body');
+            if (keywordInput) {
+                keywordInput.addEventListener('keydown', function (event) {
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        state.keyword = keywordInput.value.trim();
+                        performSearch(1);
+                    }
+                });
+            }
+            if (searchBtn) {
+                searchBtn.addEventListener('click', function () {
+                    state.keyword = keywordInput ? keywordInput.value.trim() : state.keyword;
+                    performSearch(1);
+                });
+            }
+            if (inBodyCheckbox) {
+                inBodyCheckbox.addEventListener('change', function () {
+                    state.includeBody = !!inBodyCheckbox.checked;
+                });
+            }
+
+            var selectButtons = app.querySelectorAll('button[data-action="select"]');
+            for (var i = 0; i < selectButtons.length; i++) {
+                selectButtons[i].addEventListener('click', function (event) {
+                    var id = parseInt(event.currentTarget.getAttribute('data-id'), 10);
+                    var selected = null;
+                    for (var j = 0; j < state.results.length; j++) {
+                        if (state.results[j].id === id) {
+                            selected = state.results[j];
+                            break;
+                        }
+                    }
+                    if (selected) {
+                        loadPostDetail(selected);
+                    }
+                });
+            }
+
+            var prevBtn = document.getElementById('sai-prev');
+            var nextBtn = document.getElementById('sai-next');
+            if (prevBtn) {
+                prevBtn.addEventListener('click', function () {
+                    if (state.currentPage > 1) {
+                        performSearch(state.currentPage - 1);
+                    }
+                });
+            }
+            if (nextBtn) {
+                nextBtn.addEventListener('click', function () {
+                    if (state.currentPage < state.totalPages) {
+                        performSearch(state.currentPage + 1);
+                    }
+                });
+            }
+        }
+
+        function bindDetailEvents() {
+            var backBtn = document.getElementById('sai-back');
+            if (backBtn) {
+                backBtn.addEventListener('click', function () {
+                    updateState({
+                        selectedPost: null,
+                        postDetail: null,
+                        anchors: [],
+                        quotas: null,
+                        notice: '',
+                        extracting: false
+                    });
+                });
+            }
+
+            var extractBtn = document.getElementById('sai-extract');
+            if (extractBtn) {
+                extractBtn.addEventListener('click', function () {
+                    if (!state.postDetail || state.extracting) {
+                        return;
+                    }
+                    extractAnchors();
+                });
+            }
+
+            var copyBtn = document.getElementById('sai-copy');
+            if (copyBtn) {
+                copyBtn.addEventListener('click', function () {
+                    copyAnchorsToClipboard();
+                });
+            }
+        }
+
+        function performSearch(page) {
+            if (!state.keyword) {
+                updateState({ notice: i18n.keywordRequired || 'Introduce una palabra clave.', noticeType: 'error' });
+                return;
+            }
+            updateState({ loading: true, hasSearched: true, notice: '', noticeType: 'success' });
+            var params = new URLSearchParams();
+            params.append('kw', state.keyword);
+            params.append('in_body', state.includeBody ? '1' : '0');
+            params.append('page', page || 1);
+
+            fetch(settings.restUrl + 'search?' + params.toString(), {
+                credentials: 'same-origin',
+                headers: {
+                    'X-WP-Nonce': settings.nonce
+                }
+            })
+                .then(handleFetchResponse)
+                .then(function (data) {
+                    updateState({
+                        loading: false,
+                        results: data.items || [],
+                        total: data.total || 0,
+                        totalPages: data.totalPages || 0,
+                        currentPage: page || 1,
+                        notice: '',
+                        noticeType: 'success',
+                        canonical: state.keyword
+                    });
+                })
+                .catch(function (error) {
+                    updateState({
+                        loading: false,
+                        notice: (i18n.loadError || 'Ocurrió un error. Inténtalo nuevamente.') + ' ' + (error && error.message ? error.message : ''),
+                        noticeType: 'error'
+                    });
+                });
+        }
+
+        function loadPostDetail(selected) {
+            updateState({
+                selectedPost: selected,
+                postDetail: null,
+                anchors: [],
+                quotas: null,
+                notice: '',
+                extracting: false,
+                canonical: state.keyword
+            });
+
+            fetch(settings.restUrl + 'post/' + selected.id, {
+                credentials: 'same-origin',
+                headers: {
+                    'X-WP-Nonce': settings.nonce
+                }
+            })
+                .then(handleFetchResponse)
+                .then(function (data) {
+                    updateState({ postDetail: data, canonical: state.keyword });
+                })
+                .catch(function (error) {
+                    updateState({
+                        notice: (i18n.loadError || 'Ocurrió un error. Inténtalo nuevamente.') + ' ' + (error && error.message ? error.message : ''),
+                        noticeType: 'error'
+                    });
+                });
+        }
+
+        function extractAnchors() {
+            updateState({ extracting: true, notice: '', anchors: [], quotas: null });
+            var payload = {
+                id: state.selectedPost ? state.selectedPost.id : 0,
+                canonical: state.canonical || '',
+                body_text: state.postDetail ? state.postDetail.body_text || '' : ''
+            };
+
+            fetch(settings.restUrl + 'extract', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-WP-Nonce': settings.nonce
+                },
+                body: JSON.stringify(payload)
+            })
+                .then(handleFetchResponse)
+                .then(function (data) {
+                    updateState({
+                        extracting: false,
+                        anchors: data.anchors || [],
+                        quotas: data.quotas || null,
+                        notice: '',
+                        noticeType: 'success'
+                    });
+                })
+                .catch(function (error) {
+                    updateState({
+                        extracting: false,
+                        notice: (i18n.loadError || 'Ocurrió un error. Inténtalo nuevamente.') + ' ' + (error && error.message ? error.message : ''),
+                        noticeType: 'error'
+                    });
+                });
+        }
+
+        function copyAnchorsToClipboard() {
+            if (!state.anchors || state.anchors.length === 0) {
+                updateState({ notice: i18n.noAnchors || 'No hay anchors disponibles.', noticeType: 'error' });
+                return;
+            }
+            var lines = [];
+            for (var i = 0; i < state.anchors.length; i++) {
+                var row = state.anchors[i];
+                lines.push(row.text + '\t' + row.class + '\t' + row.frequency);
+            }
+            var output = lines.join('\n');
+
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(output)
+                    .then(function () {
+                        updateState({ notice: i18n.copySuccess || 'Anchors copiados al portapapeles.', noticeType: 'success' });
+                    })
+                    .catch(function () {
+                        fallbackCopy(output);
+                    });
+            } else {
+                fallbackCopy(output);
+            }
+        }
+
+        function fallbackCopy(text) {
+            var textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.setAttribute('readonly', 'readonly');
+            textarea.style.position = 'absolute';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            try {
+                var success = document.execCommand('copy');
+                updateState({
+                    notice: success ? (i18n.copySuccess || 'Anchors copiados al portapapeles.') : (i18n.copyError || 'No se pudo copiar. Copie manualmente.'),
+                    noticeType: success ? 'success' : 'error'
+                });
+            } catch (err) {
+                updateState({
+                    notice: i18n.copyError || 'No se pudo copiar. Copie manualmente.',
+                    noticeType: 'error'
+                });
+            }
+            document.body.removeChild(textarea);
+        }
+
+        function handleFetchResponse(response) {
+            if (!response.ok) {
+                return response.json().catch(function () {
+                    return {};
+                }).then(function (data) {
+                    var message = data && data.message ? data.message : response.statusText;
+                    throw new Error(message || 'Error');
+                });
+            }
+            return response.json();
+        }
+
+        render();
+    });
+})();

--- a/includes/class-sai-anchors.php
+++ b/includes/class-sai-anchors.php
@@ -1,0 +1,561 @@
+<?php
+/**
+ * Anchor extraction logic without AI.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SAI_Anchors {
+
+    /**
+     * List of Spanish stopwords.
+     *
+     * @var array
+     */
+    protected $stopwords = [
+        'a', 'acá', 'ahí', 'al', 'algo', 'algunas', 'algunos', 'allí', 'allá', 'ante', 'antes', 'aquel', 'aquella',
+        'aquellas', 'aquellos', 'aqui', 'aquí', 'arriba', 'así', 'atrás', 'bajo', 'bastante', 'bien', 'cada', 'casi',
+        'como', 'con', 'contra', 'cual', 'cuales', 'cualquier', 'cualquiera', 'cualquieras', 'cuando', 'cuanto',
+        'cuanta', 'cuantas', 'cuantos', 'de', 'dejar', 'del', 'demás', 'demasiada', 'demasiadas', 'demasiado',
+        'demasiados', 'dentro', 'desde', 'donde', 'dos', 'el', 'él', 'ella', 'ellas', 'ellos', 'en', 'encima', 'entonces',
+        'entre', 'era', 'erais', 'eran', 'eras', 'eres', 'es', 'esa', 'esas', 'ese', 'eso', 'esos', 'esta', 'está', 'estaba',
+        'estabais', 'estaban', 'estabas', 'estad', 'estada', 'estadas', 'estado', 'estados', 'estamos', 'estando',
+        'estar', 'estaremos', 'estará', 'estarán', 'estarás', 'estaré', 'estaréis', 'estaría', 'estaríais', 'estaríamos',
+        'estarían', 'estarías', 'estas', 'estás', 'este', 'esto', 'estos', 'estoy', 'fin', 'fue', 'fueron', 'fui', 'fuimos',
+        'ha', 'habéis', 'haber', 'habrá', 'habrán', 'habrás', 'habré', 'habréis', 'habría', 'habríais', 'habríamos',
+        'habrían', 'habrías', 'haciendo', 'hace', 'haces', 'hacia', 'haciendo', 'han', 'hasta', 'hay', 'haya', 'hayan',
+        'hayas', 'he', 'hemos', 'hube', 'hubiera', 'hubierais', 'hubieran', 'hubieras', 'hubieron', 'hubiese', 'hubieseis',
+        'hubiesen', 'hubieses', 'hubimos', 'hubiste', 'hubisteis', 'la', 'las', 'le', 'les', 'lo', 'los', 'mas', 'más', 'me',
+        'mi', 'mis', 'mucho', 'muchos', 'muy', 'nada', 'ni', 'no', 'nos', 'nosotras', 'nosotros', 'nuestra', 'nuestras',
+        'nuestro', 'nuestros', 'o', 'os', 'otra', 'otras', 'otro', 'otros', 'para', 'pero', 'poca', 'pocas', 'poco', 'pocos',
+        'por', 'porque', 'primero', 'puede', 'pueden', 'pues', 'que', 'qué', 'querer', 'quien', 'quienes', 'se', 'sea',
+        'seas', 'ser', 'será', 'serán', 'serás', 'seré', 'seréis', 'sería', 'seríais', 'seríamos', 'serían', 'serías',
+        'si', 'sí', 'siempre', 'siendo', 'sin', 'sobre', 'sois', 'solamente', 'solo', 'sólo', 'somos', 'son', 'soy', 'su',
+        'sus', 'tal', 'tales', 'también', 'tampoco', 'tan', 'tanta', 'tantas', 'tanto', 'tantos', 'te', 'tenemos', 'tener',
+        'tengo', 'ti', 'tiene', 'tienen', 'toda', 'todas', 'todavía', 'todo', 'todos', 'tu', 'tus', 'un', 'una', 'uno',
+        'unos', 'vosotras', 'vosotros', 'y', 'ya', 'yo'
+    ];
+
+    /**
+     * CTA or noisy terms to exclude.
+     *
+     * @var array
+     */
+    protected $cta_terms = [
+        'whatsapp', 'compra', 'comprar', 'cotiza', 'cotizar', 'precio', 'oferta', 'ofertas', 'promocion',
+        'promociones', 'promo', 'descuentos', 'clic', 'click', 'click aqui', 'haz clic', 'suscríbete', 'suscribete',
+        'registro', 'regístrate', 'registrate', 'teléfono', 'telefono', 'moldurama', 'mx'
+    ];
+
+    /**
+     * Connector or brand words for canonical core.
+     *
+     * @var array
+     */
+    protected $connector_words = [ 'mx', 'com', 'de', 'del', 'para', 'en' ];
+
+    /**
+     * Topic core terms that must appear in anchors.
+     *
+     * @var array
+     */
+    protected $core_terms = [ 'caseton', 'poliestireno', 'eps', 'unicel', 'losa', 'reticular', '40x40x20' ];
+
+    /**
+     * Cleans raw content removing headings, scripts and HTML tags.
+     *
+     * @param string $content Raw HTML content.
+     * @return string Clean plain text.
+     */
+    public function clean_content( $content ) {
+        if ( empty( $content ) ) {
+            return '';
+        }
+
+        $content = preg_replace( '/<script[\s\S]*?<\/script>/i', ' ', $content );
+        $content = preg_replace( '/<style[\s\S]*?<\/style>/i', ' ', $content );
+        $content = preg_replace( '/<h[1-6][^>]*>[\s\S]*?<\/h[1-6]>/i', ' ', $content );
+        $content = strip_tags( $content );
+        $content = html_entity_decode( $content, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+        $content = preg_replace( '/\s+/u', ' ', $content );
+
+        return trim( $content );
+    }
+
+    /**
+     * Counts words in text.
+     *
+     * @param string $text Text to count.
+     * @return int
+     */
+    public function get_word_count( $text ) {
+        if ( empty( $text ) ) {
+            return 0;
+        }
+
+        $words = preg_split( '/[\s]+/u', trim( $text ) );
+        $words = array_filter( $words, 'strlen' );
+
+        return count( $words );
+    }
+
+    /**
+     * Extracts anchors and quotas.
+     *
+     * @param string $canonical Canonical keyword.
+     * @param string $body_text Clean body text.
+     * @return array
+     */
+    public function extract( $canonical, $body_text ) {
+        $body_text = $this->prepare_text( $body_text );
+        $canonical = trim( (string) $canonical );
+
+        if ( '' === $body_text || '' === $canonical ) {
+            return [ 'anchors' => [], 'quotas' => [ 'total' => 0, 'exacta' => 0, 'frase' => 0, 'semantica' => 0 ] ];
+        }
+
+        $word_count    = $this->get_word_count( $body_text );
+        $presets       = $this->get_presets( $word_count );
+        $normalized    = $this->normalize( $body_text );
+        $tokens        = $this->tokenize_with_positions( $body_text );
+        $candidates    = $this->generate_candidates( $tokens, $body_text );
+        $canonical_norm = $this->normalize( $canonical );
+        $canonical_core = $this->canonical_core( $canonical );
+        $canonical_core_norm = $this->normalize( $canonical_core );
+
+        $valid_candidates = [];
+
+        foreach ( $candidates as $candidate ) {
+            if ( ! $this->is_candidate_valid( $candidate, $canonical_core_norm ) ) {
+                continue;
+            }
+
+            $classification = $this->classify_candidate( $candidate['text'], $canonical_norm, $canonical_core_norm );
+
+            $frequency = $this->count_frequency( $candidate['text'], $normalized );
+            if ( $frequency < 1 ) {
+                continue;
+            }
+
+            $candidate['classification'] = $classification;
+            $candidate['frequency']      = $frequency;
+            $valid_candidates[]          = $candidate;
+        }
+
+        $deduped = $this->deduplicate_candidates( $valid_candidates );
+
+        $grouped = [ 'exacta' => [], 'frase' => [], 'semantica' => [] ];
+        foreach ( $deduped as $candidate ) {
+            $grouped[ $candidate['classification'] ][] = $candidate;
+        }
+
+        foreach ( $grouped as &$items ) {
+            usort(
+                $items,
+                function ( $a, $b ) {
+                    if ( $a['frequency'] === $b['frequency'] ) {
+                        return mb_strlen( $a['text'] ) <=> mb_strlen( $b['text'] );
+                    }
+
+                    return $b['frequency'] <=> $a['frequency'];
+                }
+            );
+        }
+        unset( $items );
+
+        $selected = [];
+        $counts   = [ 'exacta' => 0, 'frase' => 0, 'semantica' => 0 ];
+
+        // Initial allocation respecting quotas per classification order.
+        foreach ( [ 'exacta', 'frase', 'semantica' ] as $type ) {
+            $limit = isset( $presets[ $type ] ) ? (int) $presets[ $type ] : 0;
+            if ( $limit < 1 || empty( $grouped[ $type ] ) ) {
+                continue;
+            }
+            $slice = array_slice( $grouped[ $type ], 0, $limit );
+            $selected = array_merge( $selected, $slice );
+            $counts[ $type ] = count( $slice );
+        }
+
+        $total_needed = (int) $presets['total'];
+        $total_selected = count( $selected );
+
+        if ( $total_selected < $total_needed ) {
+            $fallback_order = [ 'frase', 'semantica', 'exacta' ];
+            $used_texts     = array_column( $selected, 'text' );
+
+            foreach ( $fallback_order as $type ) {
+                if ( $total_selected >= $total_needed ) {
+                    break;
+                }
+
+                if ( empty( $grouped[ $type ] ) ) {
+                    continue;
+                }
+
+                $index = $counts[ $type ];
+                while ( isset( $grouped[ $type ][ $index ] ) && $total_selected < $total_needed ) {
+                    $candidate = $grouped[ $type ][ $index ];
+                    if ( in_array( $candidate['text'], $used_texts, true ) ) {
+                        $index++;
+                        continue;
+                    }
+                    $selected[]       = $candidate;
+                    $used_texts[]     = $candidate['text'];
+                    $counts[ $type ] += 1;
+                    $total_selected++;
+                    $index++;
+                }
+            }
+        }
+
+        // Cap totals by available anchors.
+        $counts['exacta']    = min( $counts['exacta'], count( $grouped['exacta'] ) );
+        $counts['frase']     = min( $counts['frase'], count( $grouped['frase'] ) );
+        $counts['semantica'] = min( $counts['semantica'], count( $grouped['semantica'] ) );
+        $counts['total']     = count( $selected );
+
+        usort(
+            $selected,
+            function ( $a, $b ) {
+                $order = [ 'exacta' => 0, 'frase' => 1, 'semantica' => 2 ];
+                $class_cmp = $order[ $a['classification'] ] <=> $order[ $b['classification'] ];
+                if ( 0 !== $class_cmp ) {
+                    return $class_cmp;
+                }
+                if ( $a['frequency'] === $b['frequency'] ) {
+                    return mb_strlen( $a['text'] ) <=> mb_strlen( $b['text'] );
+                }
+
+                return $b['frequency'] <=> $a['frequency'];
+            }
+        );
+
+        $anchors = array_map(
+            function ( $item ) {
+                return [
+                    'text'          => $item['text'],
+                    'class'         => $item['classification'],
+                    'frequency'     => $item['frequency'],
+                ];
+            },
+            $selected
+        );
+
+        return [
+            'anchors' => $anchors,
+            'quotas'  => [
+                'total'     => $counts['total'],
+                'exacta'    => $counts['exacta'],
+                'frase'     => $counts['frase'],
+                'semantica' => $counts['semantica'],
+            ],
+        ];
+    }
+
+    /**
+     * Prepares text by collapsing whitespace.
+     *
+     * @param string $text Text to prepare.
+     * @return string
+     */
+    protected function prepare_text( $text ) {
+        $text = (string) $text;
+        $text = preg_replace( '/\s+/u', ' ', $text );
+        return trim( $text );
+    }
+
+    /**
+     * Normalizes text to lowercase without accents.
+     *
+     * @param string $text Text to normalize.
+     * @return string
+     */
+    protected function normalize( $text ) {
+        $text = wp_strip_all_tags( $text );
+        $text = strtolower( $text );
+        $text = remove_accents( $text );
+        $text = preg_replace( '/[^\p{L}0-9\s]+/u', ' ', $text );
+        $text = preg_replace( '/\s+/u', ' ', $text );
+        return trim( $text );
+    }
+
+    /**
+     * Generates canonical core string.
+     *
+     * @param string $canonical Canonical keyword.
+     * @return string
+     */
+    protected function canonical_core( $canonical ) {
+        $tokens = preg_split( '/\s+/u', strtolower( remove_accents( $canonical ) ) );
+        $filtered = array_diff( $tokens, $this->connector_words );
+        $filtered = array_filter( $filtered );
+        return implode( ' ', $filtered );
+    }
+
+    /**
+     * Tokenizes text and keeps positions.
+     *
+     * @param string $text Clean text.
+     * @return array
+     */
+    protected function tokenize_with_positions( $text ) {
+        $tokens = [];
+        if ( '' === $text ) {
+            return $tokens;
+        }
+
+        if ( preg_match_all( '/\b[\p{L}0-9][\p{L}0-9\p{Mn}\p{Pd}]*\b/u', $text, $matches, PREG_OFFSET_CAPTURE ) ) {
+            foreach ( $matches[0] as $match ) {
+                $tokens[] = [
+                    'token'  => $match[0],
+                    'offset' => $match[1],
+                    'length' => mb_strlen( $match[0] ),
+                ];
+            }
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Generates candidate anchors from tokens.
+     *
+     * @param array  $tokens Tokens with positions.
+     * @param string $text   Full text.
+     * @return array
+     */
+    protected function generate_candidates( $tokens, $text ) {
+        $candidates = [];
+        $token_count = count( $tokens );
+
+        for ( $i = 0; $i < $token_count; $i++ ) {
+            for ( $window = 2; $window <= 7; $window++ ) {
+                $end_index = $i + $window - 1;
+                if ( $end_index >= $token_count ) {
+                    break;
+                }
+
+                $start = $tokens[ $i ]['offset'];
+                $end_token = $tokens[ $end_index ];
+                $end = $end_token['offset'] + $end_token['length'];
+                $substr = mb_substr( $text, $start, $end - $start );
+                $substr = $this->prepare_text( $substr );
+                $length = mb_strlen( $substr );
+
+                if ( $length < 6 || $length > 80 ) {
+                    continue;
+                }
+
+                $candidates[] = [
+                    'text'   => $substr,
+                    'tokens' => array_slice( $tokens, $i, $window ),
+                ];
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * Validates candidate anchor.
+     *
+     * @param array  $candidate Candidate data.
+     * @param string $canonical_core_norm Normalized canonical core.
+     * @return bool
+     */
+    protected function is_candidate_valid( $candidate, $canonical_core_norm ) {
+        $text = $candidate['text'];
+        $normalized = $this->normalize( $text );
+
+        if ( '' === $normalized ) {
+            return false;
+        }
+
+        if ( preg_match( '/https?:\/\//i', $text ) || preg_match( '/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i', $text ) ) {
+            return false;
+        }
+
+        if ( preg_match( '/\b\d{2,}\b/', $text ) && preg_match( '/\b\d{7,}\b/', $text ) ) {
+            // Likely a phone number.
+            return false;
+        }
+
+        $tokens_norm = preg_split( '/\s+/u', $normalized );
+        $alpha_tokens = array_filter(
+            $tokens_norm,
+            function ( $token ) {
+                return (bool) preg_match( '/[a-z]/u', $token );
+            }
+        );
+
+        if ( count( $alpha_tokens ) < 2 ) {
+            return false;
+        }
+
+        $non_stop = array_filter(
+            $tokens_norm,
+            function ( $token ) {
+                return ! in_array( $token, $this->stopwords, true );
+            }
+        );
+
+        if ( count( $non_stop ) < 2 ) {
+            return false;
+        }
+
+        foreach ( $this->cta_terms as $term ) {
+            if ( false !== strpos( $normalized, $term ) ) {
+                return false;
+            }
+        }
+
+        $contains_core = false;
+        foreach ( $this->core_terms as $term ) {
+            if ( false !== strpos( $normalized, $term ) ) {
+                $contains_core = true;
+                break;
+            }
+        }
+
+        if ( ! $contains_core && '' !== $canonical_core_norm ) {
+            $canonical_tokens = preg_split( '/\s+/u', $canonical_core_norm );
+            foreach ( $canonical_tokens as $core_token ) {
+                if ( '' !== $core_token && false !== strpos( $normalized, $core_token ) ) {
+                    $contains_core = true;
+                    break;
+                }
+            }
+        }
+
+        if ( ! $contains_core ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Classifies candidate anchor.
+     *
+     * @param string $anchor_text Anchor.
+     * @param string $canonical_norm Normalized canonical string.
+     * @param string $canonical_core_norm Normalized canonical core string.
+     * @return string
+     */
+    protected function classify_candidate( $anchor_text, $canonical_norm, $canonical_core_norm ) {
+        $anchor_norm = $this->normalize( $anchor_text );
+
+        if ( '' !== $canonical_norm && $anchor_norm === $canonical_norm ) {
+            return 'exacta';
+        }
+
+        if ( '' !== $canonical_core_norm && $anchor_norm === $canonical_core_norm ) {
+            return 'exacta';
+        }
+
+        if ( '' !== $canonical_norm && false !== strpos( $anchor_norm, $canonical_norm ) ) {
+            return 'frase';
+        }
+
+        if ( '' !== $canonical_core_norm && false !== strpos( $anchor_norm, $canonical_core_norm ) ) {
+            return 'frase';
+        }
+
+        return 'semantica';
+    }
+
+    /**
+     * Counts frequency of anchor in normalized text.
+     *
+     * @param string $anchor_text Anchor text.
+     * @param string $normalized_text Normalized text.
+     * @return int
+     */
+    protected function count_frequency( $anchor_text, $normalized_text ) {
+        $anchor_norm = $this->normalize( $anchor_text );
+        if ( '' === $anchor_norm ) {
+            return 0;
+        }
+
+        $pattern = '/\b' . preg_quote( $anchor_norm, '/' ) . '\b/u';
+        if ( preg_match_all( $pattern, $normalized_text, $matches ) ) {
+            return count( $matches[0] );
+        }
+
+        return substr_count( $normalized_text, $anchor_norm );
+    }
+
+    /**
+     * Removes duplicates based on signature.
+     *
+     * @param array $candidates Candidate anchors.
+     * @return array
+     */
+    protected function deduplicate_candidates( $candidates ) {
+        $signatures = [];
+
+        foreach ( $candidates as $candidate ) {
+            $tokens = preg_split( '/\s+/u', $this->normalize( $candidate['text'] ) );
+            $signature_tokens = [];
+            foreach ( $tokens as $token ) {
+                if ( '' === $token || in_array( $token, $this->stopwords, true ) ) {
+                    continue;
+                }
+                $signature_tokens[] = $token;
+            }
+            $signature = implode( ' ', $signature_tokens );
+            if ( '' === $signature ) {
+                $signature = $this->normalize( $candidate['text'] );
+            }
+
+            if ( isset( $signatures[ $signature ] ) ) {
+                $existing = $signatures[ $signature ];
+                if ( $candidate['frequency'] > $existing['frequency'] ) {
+                    $signatures[ $signature ] = $candidate;
+                } elseif ( $candidate['frequency'] === $existing['frequency'] && mb_strlen( $candidate['text'] ) < mb_strlen( $existing['text'] ) ) {
+                    $signatures[ $signature ] = $candidate;
+                }
+            } else {
+                $signatures[ $signature ] = $candidate;
+            }
+        }
+
+        return array_values( $signatures );
+    }
+
+    /**
+     * Calculates presets based on word count.
+     *
+     * @param int $word_count Number of words.
+     * @return array
+     */
+    public function get_presets( $word_count ) {
+        if ( $word_count <= 700 ) {
+            return [
+                'total'     => 4,
+                'exacta'    => 1,
+                'frase'     => 1,
+                'semantica' => 2,
+            ];
+        }
+
+        if ( $word_count <= 1500 ) {
+            return [
+                'total'     => 6,
+                'exacta'    => 1,
+                'frase'     => 3,
+                'semantica' => 2,
+            ];
+        }
+
+        return [
+            'total'     => 8,
+            'exacta'    => 1,
+            'frase'     => 4,
+            'semantica' => 3,
+        ];
+    }
+}

--- a/includes/class-sai-rest.php
+++ b/includes/class-sai-rest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * REST controller for Anchors sin IA.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SAI_REST_Controller {
+
+    /**
+     * Namespace.
+     */
+    const REST_NAMESPACE = 'anchors/v1';
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+    }
+
+    /**
+     * Registers routes.
+     */
+    public function register_routes() {
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/search',
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'handle_search' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+                'args'                => [
+                    'kw'      => [
+                        'type'     => 'string',
+                        'required' => true,
+                    ],
+                    'in_body' => [
+                        'type'              => 'integer',
+                        'required'          => false,
+                        'default'           => 0,
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'page'    => [
+                        'type'              => 'integer',
+                        'required'          => false,
+                        'default'           => 1,
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/post/(?P<id>\d+)',
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'handle_get_post' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+                'args'                => [
+                    'id' => [
+                        'type'              => 'integer',
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/extract',
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'handle_extract' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+                'args'                => [
+                    'id'        => [
+                        'type'              => 'integer',
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'canonical' => [
+                        'type'     => 'string',
+                        'required' => true,
+                    ],
+                    'body_text' => [
+                        'type'     => 'string',
+                        'required' => true,
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Permission callback.
+     *
+     * @return bool
+     */
+    public function permission_check() {
+        return current_user_can( 'edit_posts' );
+    }
+
+    /**
+     * Handles search endpoint.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response
+     */
+    public function handle_search( WP_REST_Request $request ) {
+        $keyword = trim( (string) $request->get_param( 'kw' ) );
+        if ( '' === $keyword ) {
+            return rest_ensure_response(
+                [
+                    'items'      => [],
+                    'total'      => 0,
+                    'totalPages' => 0,
+                ]
+            );
+        }
+
+        $in_body = (bool) $request->get_param( 'in_body' );
+        $page    = max( 1, (int) $request->get_param( 'page' ) );
+
+        $args = [
+            'post_type'           => [ 'post', 'page' ],
+            'post_status'         => 'publish',
+            'posts_per_page'      => 50,
+            'paged'               => $page,
+            's'                   => $keyword,
+            'ignore_sticky_posts' => true,
+        ];
+
+        if ( ! $in_body ) {
+            $args['search_columns'] = [ 'post_title' ];
+        } else {
+            $args['search_columns'] = [ 'post_title', 'post_content' ];
+        }
+
+        $query = new WP_Query( $args );
+
+        $items = [];
+        foreach ( $query->posts as $post ) {
+            $items[] = [
+                'id'    => $post->ID,
+                'title' => get_the_title( $post ),
+                'type'  => $post->post_type,
+                'link'  => get_permalink( $post ),
+            ];
+        }
+
+        wp_reset_postdata();
+
+        return rest_ensure_response(
+            [
+                'items'      => $items,
+                'total'      => (int) $query->found_posts,
+                'totalPages' => (int) $query->max_num_pages,
+            ]
+        );
+    }
+
+    /**
+     * Returns post detail without headings.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response
+     */
+    public function handle_get_post( WP_REST_Request $request ) {
+        $post_id = (int) $request['id'];
+        $post    = get_post( $post_id );
+
+        if ( ! $post || ! in_array( $post->post_type, [ 'post', 'page' ], true ) || 'publish' !== $post->post_status ) {
+            return new WP_Error( 'sai_not_found', __( 'Entrada no encontrada.', 'anchors-sin-ia' ), [ 'status' => 404 ] );
+        }
+
+        $anchors = new SAI_Anchors();
+        $content = get_post_field( 'post_content', $post );
+        $content = strip_shortcodes( $content );
+        $clean   = $anchors->clean_content( $content );
+        $words   = $anchors->get_word_count( $clean );
+
+        return rest_ensure_response(
+            [
+                'id'         => $post->ID,
+                'title'      => get_the_title( $post ),
+                'body_text'  => $clean,
+                'word_count' => $words,
+            ]
+        );
+    }
+
+    /**
+     * Handles extraction endpoint.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response
+     */
+    public function handle_extract( WP_REST_Request $request ) {
+        $id        = (int) $request->get_param( 'id' );
+        $canonical = sanitize_text_field( $request->get_param( 'canonical' ) );
+        $body_text = (string) $request->get_param( 'body_text' );
+
+        $post = get_post( $id );
+        if ( ! $post || ! in_array( $post->post_type, [ 'post', 'page' ], true ) ) {
+            return new WP_Error( 'sai_not_found', __( 'Entrada no encontrada.', 'anchors-sin-ia' ), [ 'status' => 404 ] );
+        }
+
+        $anchors = new SAI_Anchors();
+        $clean   = $anchors->clean_content( $body_text );
+        if ( '' === $clean ) {
+            $clean = $anchors->clean_content( get_post_field( 'post_content', $post ) );
+        }
+
+        $result = $anchors->extract( $canonical, $clean );
+
+        return rest_ensure_response( $result );
+    }
+}

--- a/sai-plugin.php
+++ b/sai-plugin.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Plugin Name: Anchors sin IA
+ * Description: Herramienta para buscar entradas y extraer anchors sin IA.
+ * Version: 1.0.0
+ * Author: OpenAI
+ * Text Domain: anchors-sin-ia
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! defined( 'SAI_PLUGIN_FILE' ) ) {
+    define( 'SAI_PLUGIN_FILE', __FILE__ );
+}
+
+define( 'SAI_PLUGIN_DIR', plugin_dir_path( SAI_PLUGIN_FILE ) );
+define( 'SAI_PLUGIN_URL', plugin_dir_url( SAI_PLUGIN_FILE ) );
+
+require_once SAI_PLUGIN_DIR . 'includes/class-sai-anchors.php';
+require_once SAI_PLUGIN_DIR . 'includes/class-sai-rest.php';
+
+class Anchors_Sin_IA_Plugin {
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_admin_page' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        new SAI_REST_Controller();
+    }
+
+    /**
+     * Registers the admin page under Tools.
+     */
+    public function register_admin_page() {
+        add_management_page(
+            __( 'Anchors sin IA', 'anchors-sin-ia' ),
+            __( 'Anchors sin IA', 'anchors-sin-ia' ),
+            'edit_posts',
+            'anchors-sin-ia',
+            [ $this, 'render_admin_page' ]
+        );
+    }
+
+    /**
+     * Outputs the container for the admin app.
+     */
+    public function render_admin_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Anchors sin IA', 'anchors-sin-ia' ) . '</h1><div id="sai-app"></div></div>';
+    }
+
+    /**
+     * Enqueue assets only on plugin page.
+     *
+     * @param string $hook Current admin page hook.
+     */
+    public function enqueue_assets( $hook ) {
+        if ( 'tools_page_anchors-sin-ia' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'anchors-sin-ia-admin',
+            SAI_PLUGIN_URL . 'assets/admin.css',
+            [],
+            '1.0.0'
+        );
+
+        wp_enqueue_script(
+            'anchors-sin-ia-admin',
+            SAI_PLUGIN_URL . 'assets/admin.js',
+            [],
+            '1.0.0',
+            true
+        );
+
+        wp_localize_script(
+            'anchors-sin-ia-admin',
+            'AnchorsSinIA',
+            [
+                'restUrl' => esc_url_raw( rest_url( 'anchors/v1/' ) ),
+                'nonce'   => wp_create_nonce( 'wp_rest' ),
+                'perPage' => 50,
+                'i18n'    => [
+                    'search'         => __( 'Buscar', 'anchors-sin-ia' ),
+                    'view'           => __( 'Ver', 'anchors-sin-ia' ),
+                    'select'         => __( 'Seleccionar', 'anchors-sin-ia' ),
+                    'noResults'      => __( 'Sin resultados.', 'anchors-sin-ia' ),
+                    'copySuccess'    => __( 'Anchors copiados al portapapeles.', 'anchors-sin-ia' ),
+                    'copyError'      => __( 'No se pudo copiar. Copie manualmente.', 'anchors-sin-ia' ),
+                    'loading'        => __( 'Cargando...', 'anchors-sin-ia' ),
+                    'keywordLabel'   => __( 'Palabra clave (canónico)', 'anchors-sin-ia' ),
+                    'includeBody'    => __( 'Buscar también en el contenido', 'anchors-sin-ia' ),
+                    'wordCount'      => __( 'Palabras', 'anchors-sin-ia' ),
+                    'preset'         => __( 'Preset', 'anchors-sin-ia' ),
+                    'extractAnchors' => __( 'Extraer anchors', 'anchors-sin-ia' ),
+                    'copyAnchors'    => __( 'Copiar anchors', 'anchors-sin-ia' ),
+                    'tableHeader'    => [ __( 'Anchor', 'anchors-sin-ia' ), __( 'Clasificación', 'anchors-sin-ia' ), __( 'Frecuencia', 'anchors-sin-ia' ) ],
+                    'keywordRequired'=> __( 'Introduce una palabra clave.', 'anchors-sin-ia' ),
+                    'loadError'      => __( 'Ocurrió un error. Inténtalo nuevamente.', 'anchors-sin-ia' ),
+                    'noAnchors'      => __( 'No hay anchors disponibles.', 'anchors-sin-ia' ),
+                    'back'           => __( 'Volver a la búsqueda', 'anchors-sin-ia' ),
+                    'extracting'     => __( 'Extrayendo...', 'anchors-sin-ia' ),
+                    'pageLabel'      => __( 'Página', 'anchors-sin-ia' ),
+                    'usedQuotas'     => __( 'Cuotas usadas', 'anchors-sin-ia' ),
+                ],
+            ]
+        );
+    }
+}
+
+new Anchors_Sin_IA_Plugin();


### PR DESCRIPTION
## Summary
- add plugin bootstrap that registers the Anchors sin IA admin page and enqueues localized assets
- expose search, post detail, and anchor extraction REST endpoints backed by the SAI_Anchors logic
- build the non-AI anchor extraction engine along with the vanilla JS admin UI and styling

## Testing
- php -l sai-plugin.php
- php -l includes/class-sai-rest.php
- php -l includes/class-sai-anchors.php

------
https://chatgpt.com/codex/tasks/task_e_68e5e118c390833286c640b44fa528ac