### PR TITLE
Add linkbuilder workflow with dynamic cannibalization scoring

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1,0 +1,285 @@
+#sai-app {
+    margin-top: 20px;
+}
+
+.sai-search {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    padding: 20px;
+    border-radius: 4px;
+}
+
+.sai-search-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: flex-end;
+}
+
+.sai-label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 600;
+}
+
+.sai-label input {
+    margin-top: 6px;
+    min-width: 280px;
+    padding: 6px 8px;
+}
+
+.sai-search-actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.sai-checkbox {
+    display: flex;
+    align-items: center;
+    font-weight: 500;
+}
+
+.sai-checkbox input {
+    margin-right: 6px;
+}
+
+.sai-results {
+    margin-top: 20px;
+    display: grid;
+    gap: 12px;
+}
+
+.sai-result {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    background: #f9f9f9;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.sai-result-info h3 {
+    margin: 0 0 6px;
+    font-size: 16px;
+}
+
+.sai-result-meta {
+    margin: 0;
+    color: #555d66;
+    font-size: 13px;
+}
+
+.sai-result-actions .button {
+    margin-left: 6px;
+}
+
+.sai-status {
+    margin: 16px 0;
+    color: #555d66;
+}
+
+.sai-pagination {
+    margin-top: 16px;
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+.sai-pagination span {
+    font-weight: 600;
+}
+
+.sai-detail {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    padding: 20px;
+    border-radius: 4px;
+}
+
+.sai-detail-header {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.sai-detail-columns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+    margin-top: 16px;
+}
+
+.sai-detail-left {
+    flex: 1 1 240px;
+    background: #f6f7f7;
+    border: 1px solid #dcdcde;
+    padding: 16px;
+    border-radius: 4px;
+}
+
+.sai-detail-left p {
+    margin: 0 0 12px;
+}
+
+.sai-detail-right {
+    flex: 2 1 420px;
+}
+
+.sai-body-text {
+    width: 100%;
+    min-height: 240px;
+    resize: vertical;
+    margin: 12px 0;
+}
+
+.sai-table-wrapper {
+    margin-top: 16px;
+    max-height: 320px;
+    overflow: auto;
+}
+
+.sai-notice {
+    margin: 16px 0;
+    padding: 12px 16px;
+    border-left: 4px solid;
+    border-radius: 3px;
+}
+
+.sai-notice-success {
+    background: #f0f6f0;
+    border-color: #46b450;
+    color: #205522;
+}
+
+.sai-notice-error {
+    background: #fbeaea;
+    border-color: #dc3232;
+    color: #8a1f1f;
+}
+
+@media (max-width: 782px) {
+    .sai-search-actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .sai-result {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .sai-result-actions .button {
+        margin-left: 0;
+        margin-right: 6px;
+    }
+
+    .sai-detail-header {
+        justify-content: flex-start;
+        margin-bottom: 12px;
+    }
+}
+
+#sai-linkbuilder-app {
+    margin-top: 20px;
+}
+
+.sai-lb-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.sai-lb-steps {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    gap: 12px;
+}
+
+.sai-lb-step-item {
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: #f3f4f5;
+    cursor: pointer;
+    font-weight: 600;
+    border: 1px solid transparent;
+}
+
+.sai-lb-step-item.is-active {
+    background: #2271b1;
+    color: #fff;
+}
+
+.sai-lb-step-item.is-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.sai-lb-actions {
+    display: flex;
+    gap: 12px;
+}
+
+.sai-lb-step-content .sai-search,
+.sai-lb-step-content .sai-results,
+.sai-lb-step-content .sai-summary {
+    margin-bottom: 16px;
+}
+
+.sai-canonical-field {
+    margin-top: 12px;
+}
+
+.sai-step-actions {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    margin-top: 16px;
+}
+
+.sai-summary-card {
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    padding: 12px;
+    margin-bottom: 12px;
+    background: #fff;
+}
+
+.sai-anchor-list {
+    list-style: disc;
+    padding-left: 20px;
+}
+
+.sai-tag {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 2px 6px;
+    background: #f3f4f5;
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.sai-semaforo {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-weight: 600;
+    color: #fff;
+}
+
+.sai-semaforo--amarillo {
+    background: #f39c12;
+}
+
+.sai-semaforo--naranja {
+    background: #e67e22;
+}
+
+.sai-semaforo--rojo {
+    background: #d63638;
+}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,0 +1,448 @@
+(function () {
+    'use strict';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var settings = window.AnchorsSinIA || {};
+        var app = document.getElementById('sai-app');
+        if (!app || !settings.restUrl) {
+            return;
+        }
+
+        var state = {
+            keyword: '',
+            includeBody: false,
+            loading: false,
+            results: [],
+            total: 0,
+            totalPages: 0,
+            currentPage: 1,
+            hasSearched: false,
+            selectedPost: null,
+            postDetail: null,
+            anchors: [],
+            quotas: null,
+            notice: '',
+            noticeType: 'success',
+            canonical: '',
+            extracting: false
+        };
+
+        var i18n = settings.i18n || {};
+
+        function updateState(updates) {
+            for (var key in updates) {
+                if (Object.prototype.hasOwnProperty.call(updates, key)) {
+                    state[key] = updates[key];
+                }
+            }
+            render();
+        }
+
+        function getPreset(wordCount) {
+            if (wordCount <= 700) {
+                return { total: 4, exacta: 1, frase: 1, semantica: 2 };
+            }
+            if (wordCount <= 1500) {
+                return { total: 6, exacta: 1, frase: 3, semantica: 2 };
+            }
+            return { total: 8, exacta: 1, frase: 4, semantica: 3 };
+        }
+
+        function renderNotice() {
+            if (!state.notice) {
+                return '';
+            }
+            var typeClass = state.noticeType === 'error' ? 'sai-notice-error' : 'sai-notice-success';
+            return '<div class="sai-notice ' + typeClass + '">' + escapeHtml(state.notice) + '</div>';
+        }
+
+        function escapeHtml(text) {
+            if (!text && text !== 0) {
+                return '';
+            }
+            return String(text)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        function renderSearch() {
+            var html = '';
+            html += '<div class="sai-search">';
+            html += '<div class="sai-search-controls">';
+            html += '<label class="sai-label">' + escapeHtml(i18n.keywordLabel || 'Palabra clave (canónico)') +
+                '<input type="text" id="sai-keyword" value="' + escapeHtml(state.keyword) + '" placeholder="' + escapeHtml(i18n.keywordLabel || '') + '"></label>';
+            html += '<div class="sai-search-actions">';
+            html += '<label class="sai-checkbox"><input type="checkbox" id="sai-in-body" ' + (state.includeBody ? 'checked' : '') + '> ' + escapeHtml(i18n.includeBody || '') + '</label>';
+            html += '<button type="button" id="sai-search-btn" class="button button-primary">' + escapeHtml(i18n.search || 'Buscar') + '</button>';
+            html += '</div></div>';
+            html += renderNotice();
+            html += '<div id="sai-results" class="sai-results">';
+
+            if (state.loading) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+            } else if (state.hasSearched && state.results.length === 0) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.noResults || 'Sin resultados.') + '</p>';
+            } else {
+                for (var i = 0; i < state.results.length; i++) {
+                    var item = state.results[i];
+                    html += '<div class="sai-result">';
+                    html += '<div class="sai-result-info">';
+                    html += '<h3>' + escapeHtml(item.title) + '</h3>';
+                    html += '<p class="sai-result-meta">' + escapeHtml(item.type) + '</p>';
+                    html += '</div>';
+                    html += '<div class="sai-result-actions">';
+                    html += '<a class="button" href="' + escapeHtml(item.link) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(i18n.view || 'Ver') + '</a>';
+                    html += '<button type="button" class="button button-primary" data-action="select" data-id="' + item.id + '">' + escapeHtml(i18n.select || 'Seleccionar') + '</button>';
+                    html += '</div>';
+                    html += '</div>';
+                }
+            }
+
+            html += '</div>';
+
+            if (state.totalPages > 1) {
+                html += '<div class="sai-pagination">';
+                html += '<button type="button" class="button" id="sai-prev" ' + (state.currentPage <= 1 ? 'disabled' : '') + '>&laquo;</button>';
+                html += '<span>' + escapeHtml((i18n.pageLabel || 'Página') + ' ' + state.currentPage + ' / ' + state.totalPages) + '</span>';
+                html += '<button type="button" class="button" id="sai-next" ' + (state.currentPage >= state.totalPages ? 'disabled' : '') + '>&raquo;</button>';
+                html += '</div>';
+            }
+
+            html += '</div>';
+
+            app.innerHTML = html;
+            bindSearchEvents();
+        }
+
+        function renderDetail() {
+            var preset = getPreset(state.postDetail && state.postDetail.word_count ? state.postDetail.word_count : 0);
+            var html = '';
+            html += '<div class="sai-detail">';
+            html += '<div class="sai-detail-header">';
+            html += '<button type="button" class="button" id="sai-back">' + escapeHtml(i18n.back || 'Volver a la búsqueda') + '</button>';
+            html += '</div>';
+            html += renderNotice();
+            if (!state.postDetail) {
+                if (!state.notice) {
+                    html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+                }
+                html += '</div>';
+                app.innerHTML = html;
+                bindDetailEvents();
+                return;
+            }
+            html += '<div class="sai-detail-columns">';
+            html += '<div class="sai-detail-left">';
+            html += '<p><strong>' + escapeHtml(i18n.keywordLabel || 'Palabra clave (canónico)') + ':</strong> ' + escapeHtml(state.canonical) + '</p>';
+            html += '<p><strong>' + escapeHtml(i18n.wordCount || 'Palabras') + ':</strong> ' + (state.postDetail.word_count || 0) + '</p>';
+            html += '<p><strong>' + escapeHtml(i18n.preset || 'Preset') + ':</strong> ' + preset.total + ' (Exacta ' + preset.exacta + ' / Frase ' + preset.frase + ' / Semántica ' + preset.semantica + ')</p>';
+            if (state.quotas) {
+                html += '<p><strong>' + escapeHtml(i18n.usedQuotas || 'Cuotas usadas') + ':</strong> ' + state.quotas.total + ' (Exacta ' + state.quotas.exacta + ' / Frase ' + state.quotas.frase + ' / Semántica ' + state.quotas.semantica + ')</p>';
+            }
+            html += '</div>';
+            html += '<div class="sai-detail-right">';
+            html += '<h2>' + escapeHtml((state.postDetail && state.postDetail.title) || (state.selectedPost && state.selectedPost.title) || '') + '</h2>';
+            html += '<textarea readonly class="sai-body-text" id="sai-body-text">' + escapeHtml(state.postDetail.body_text || '') + '</textarea>';
+            html += '<button type="button" class="button button-primary" id="sai-extract" ' + (state.extracting ? 'disabled' : '') + '>' + escapeHtml(state.extracting ? (i18n.extracting || 'Extrayendo...') : (i18n.extractAnchors || 'Extraer anchors')) + '</button>';
+            if (state.extracting) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+            }
+            if (state.anchors && state.anchors.length > 0) {
+                html += '<div class="sai-table-wrapper">';
+                html += '<table class="widefat fixed">';
+                html += '<thead><tr><th>' + escapeHtml((i18n.tableHeader && i18n.tableHeader[0]) || 'Anchor') + '</th><th>' + escapeHtml((i18n.tableHeader && i18n.tableHeader[1]) || 'Clasificación') + '</th><th>' + escapeHtml((i18n.tableHeader && i18n.tableHeader[2]) || 'Frecuencia') + '</th></tr></thead>';
+                html += '<tbody>';
+                for (var i = 0; i < state.anchors.length; i++) {
+                    var anchor = state.anchors[i];
+                    html += '<tr><td>' + escapeHtml(anchor.text) + '</td><td>' + escapeHtml(anchor.class) + '</td><td>' + escapeHtml(anchor.frequency) + '</td></tr>';
+                }
+                html += '</tbody></table>';
+                html += '</div>';
+                html += '<button type="button" class="button" id="sai-copy">' + escapeHtml(i18n.copyAnchors || 'Copiar anchors') + '</button>';
+            } else if (!state.extracting && state.quotas) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.noAnchors || 'No hay anchors disponibles.') + '</p>';
+            }
+            html += '</div>';
+            html += '</div>';
+            html += '</div>';
+
+            app.innerHTML = html;
+            bindDetailEvents();
+        }
+
+        function render() {
+            if (state.selectedPost) {
+                renderDetail();
+            } else {
+                renderSearch();
+            }
+        }
+
+        function bindSearchEvents() {
+            var keywordInput = document.getElementById('sai-keyword');
+            var searchBtn = document.getElementById('sai-search-btn');
+            var inBodyCheckbox = document.getElementById('sai-in-body');
+            if (keywordInput) {
+                keywordInput.addEventListener('keydown', function (event) {
+                    if (event.key === 'Enter') {
+                        event.preventDefault();
+                        state.keyword = keywordInput.value.trim();
+                        performSearch(1);
+                    }
+                });
+            }
+            if (searchBtn) {
+                searchBtn.addEventListener('click', function () {
+                    state.keyword = keywordInput ? keywordInput.value.trim() : state.keyword;
+                    performSearch(1);
+                });
+            }
+            if (inBodyCheckbox) {
+                inBodyCheckbox.addEventListener('change', function () {
+                    state.includeBody = !!inBodyCheckbox.checked;
+                });
+            }
+
+            var selectButtons = app.querySelectorAll('button[data-action="select"]');
+            for (var i = 0; i < selectButtons.length; i++) {
+                selectButtons[i].addEventListener('click', function (event) {
+                    var id = parseInt(event.currentTarget.getAttribute('data-id'), 10);
+                    var selected = null;
+                    for (var j = 0; j < state.results.length; j++) {
+                        if (state.results[j].id === id) {
+                            selected = state.results[j];
+                            break;
+                        }
+                    }
+                    if (selected) {
+                        loadPostDetail(selected);
+                    }
+                });
+            }
+
+            var prevBtn = document.getElementById('sai-prev');
+            var nextBtn = document.getElementById('sai-next');
+            if (prevBtn) {
+                prevBtn.addEventListener('click', function () {
+                    if (state.currentPage > 1) {
+                        performSearch(state.currentPage - 1);
+                    }
+                });
+            }
+            if (nextBtn) {
+                nextBtn.addEventListener('click', function () {
+                    if (state.currentPage < state.totalPages) {
+                        performSearch(state.currentPage + 1);
+                    }
+                });
+            }
+        }
+
+        function bindDetailEvents() {
+            var backBtn = document.getElementById('sai-back');
+            if (backBtn) {
+                backBtn.addEventListener('click', function () {
+                    updateState({
+                        selectedPost: null,
+                        postDetail: null,
+                        anchors: [],
+                        quotas: null,
+                        notice: '',
+                        extracting: false
+                    });
+                });
+            }
+
+            var extractBtn = document.getElementById('sai-extract');
+            if (extractBtn) {
+                extractBtn.addEventListener('click', function () {
+                    if (!state.postDetail || state.extracting) {
+                        return;
+                    }
+                    extractAnchors();
+                });
+            }
+
+            var copyBtn = document.getElementById('sai-copy');
+            if (copyBtn) {
+                copyBtn.addEventListener('click', function () {
+                    copyAnchorsToClipboard();
+                });
+            }
+        }
+
+        function performSearch(page) {
+            if (!state.keyword) {
+                updateState({ notice: i18n.keywordRequired || 'Introduce una palabra clave.', noticeType: 'error' });
+                return;
+            }
+            updateState({ loading: true, hasSearched: true, notice: '', noticeType: 'success' });
+            var params = new URLSearchParams();
+            params.append('kw', state.keyword);
+            params.append('in_body', state.includeBody ? '1' : '0');
+            params.append('page', page || 1);
+
+            fetch(settings.restUrl + 'search?' + params.toString(), {
+                credentials: 'same-origin',
+                headers: {
+                    'X-WP-Nonce': settings.nonce
+                }
+            })
+                .then(handleFetchResponse)
+                .then(function (data) {
+                    updateState({
+                        loading: false,
+                        results: data.items || [],
+                        total: data.total || 0,
+                        totalPages: data.totalPages || 0,
+                        currentPage: page || 1,
+                        notice: '',
+                        noticeType: 'success',
+                        canonical: state.keyword
+                    });
+                })
+                .catch(function (error) {
+                    updateState({
+                        loading: false,
+                        notice: (i18n.loadError || 'Ocurrió un error. Inténtalo nuevamente.') + ' ' + (error && error.message ? error.message : ''),
+                        noticeType: 'error'
+                    });
+                });
+        }
+
+        function loadPostDetail(selected) {
+            updateState({
+                selectedPost: selected,
+                postDetail: null,
+                anchors: [],
+                quotas: null,
+                notice: '',
+                extracting: false,
+                canonical: state.keyword
+            });
+
+            fetch(settings.restUrl + 'post/' + selected.id, {
+                credentials: 'same-origin',
+                headers: {
+                    'X-WP-Nonce': settings.nonce
+                }
+            })
+                .then(handleFetchResponse)
+                .then(function (data) {
+                    updateState({ postDetail: data, canonical: state.keyword });
+                })
+                .catch(function (error) {
+                    updateState({
+                        notice: (i18n.loadError || 'Ocurrió un error. Inténtalo nuevamente.') + ' ' + (error && error.message ? error.message : ''),
+                        noticeType: 'error'
+                    });
+                });
+        }
+
+        function extractAnchors() {
+            updateState({ extracting: true, notice: '', anchors: [], quotas: null });
+            var payload = {
+                id: state.selectedPost ? state.selectedPost.id : 0,
+                canonical: state.canonical || '',
+                body_text: state.postDetail ? state.postDetail.body_text || '' : ''
+            };
+
+            fetch(settings.restUrl + 'extract', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-WP-Nonce': settings.nonce
+                },
+                body: JSON.stringify(payload)
+            })
+                .then(handleFetchResponse)
+                .then(function (data) {
+                    var updatedDetail = state.postDetail ? JSON.parse(JSON.stringify(state.postDetail)) : null;
+                    if (updatedDetail && typeof data.word_count === 'number') {
+                        updatedDetail.word_count = data.word_count;
+                    }
+                    updateState({
+                        extracting: false,
+                        anchors: data.anchors || [],
+                        quotas: data.quotas || null,
+                        postDetail: updatedDetail || state.postDetail,
+                        notice: '',
+                        noticeType: 'success'
+                    });
+                })
+                .catch(function (error) {
+                    updateState({
+                        extracting: false,
+                        notice: (i18n.loadError || 'Ocurrió un error. Inténtalo nuevamente.') + ' ' + (error && error.message ? error.message : ''),
+                        noticeType: 'error'
+                    });
+                });
+        }
+
+        function copyAnchorsToClipboard() {
+            if (!state.anchors || state.anchors.length === 0) {
+                updateState({ notice: i18n.noAnchors || 'No hay anchors disponibles.', noticeType: 'error' });
+                return;
+            }
+            var lines = [];
+            for (var i = 0; i < state.anchors.length; i++) {
+                var row = state.anchors[i];
+                lines.push(row.text + '\t' + row.class + '\t' + row.frequency);
+            }
+            var output = lines.join('\n');
+
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(output)
+                    .then(function () {
+                        updateState({ notice: i18n.copySuccess || 'Anchors copiados al portapapeles.', noticeType: 'success' });
+                    })
+                    .catch(function () {
+                        fallbackCopy(output);
+                    });
+            } else {
+                fallbackCopy(output);
+            }
+        }
+
+        function fallbackCopy(text) {
+            var textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.setAttribute('readonly', 'readonly');
+            textarea.style.position = 'absolute';
+            textarea.style.left = '-9999px';
+            document.body.appendChild(textarea);
+            textarea.select();
+            try {
+                var success = document.execCommand('copy');
+                updateState({
+                    notice: success ? (i18n.copySuccess || 'Anchors copiados al portapapeles.') : (i18n.copyError || 'No se pudo copiar. Copie manualmente.'),
+                    noticeType: success ? 'success' : 'error'
+                });
+            } catch (err) {
+                updateState({
+                    notice: i18n.copyError || 'No se pudo copiar. Copie manualmente.',
+                    noticeType: 'error'
+                });
+            }
+            document.body.removeChild(textarea);
+        }
+
+        function handleFetchResponse(response) {
+            if (!response.ok) {
+                return response.json().catch(function () {
+                    return {};
+                }).then(function (data) {
+                    var message = data && data.message ? data.message : response.statusText;
+                    throw new Error(message || 'Error');
+                });
+            }
+            return response.json();
+        }
+
+        render();
+    });
+})();

--- a/assets/linkbuilder.js
+++ b/assets/linkbuilder.js
@@ -1,0 +1,823 @@
+(function () {
+    'use strict';
+
+    function escapeHtml(text) {
+        if (!text && text !== 0) {
+            return '';
+        }
+        return String(text)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var settings = window.AnchorsSinIALinkbuilder || {};
+        var container = document.getElementById('sai-linkbuilder-app');
+        if (!container || !settings.restUrl) {
+            return;
+        }
+
+        var perPage = parseInt(settings.perPage, 10) || 50;
+        var i18n = settings.i18n || {};
+
+        var searchDefault = function () {
+            return {
+                keyword: '',
+                includeBody: false,
+                page: 1,
+                items: [],
+                total: 0,
+                totalPages: 0,
+                hasSearched: false,
+            };
+        };
+
+        var uiState = {
+            currentStep: getStepFromUrl(),
+            loading: false,
+            notice: '',
+            noticeType: 'success',
+            appState: null,
+            canonicalInput: '',
+            madreSelection: null,
+            madreAnchorsPreview: [],
+            hijasSelection: [],
+            nietasSelection: [],
+            searches: {
+                madre: searchDefault(),
+                hijas: searchDefault(),
+                nietas: searchDefault(),
+            },
+        };
+
+        var eventsBound = false;
+
+        function getStepFromUrl() {
+            var params = new URLSearchParams(window.location.search);
+            var step = parseInt(params.get('step'), 10);
+            if (!step || step < 1 || step > 4) {
+                step = 1;
+            }
+            return step;
+        }
+
+        function updateUrlStep(step) {
+            var url = new URL(window.location.href);
+            url.searchParams.set('step', step);
+            window.history.replaceState({}, '', url.toString());
+        }
+
+        function setNotice(message, type) {
+            uiState.notice = message || '';
+            uiState.noticeType = type || 'success';
+        }
+
+        function clearNotice() {
+            setNotice('', 'success');
+        }
+
+        function apiFetch(path, options) {
+            options = options || {};
+            options.headers = options.headers || {};
+            options.headers['X-WP-Nonce'] = settings.nonce || '';
+            if (!options.headers['Content-Type'] && options.method && options.method.toUpperCase() === 'POST' && options.body) {
+                options.headers['Content-Type'] = 'application/json';
+            }
+            return fetch(settings.restUrl + path, options).then(function (response) {
+                if (!response.ok) {
+                    return response.json().catch(function () {
+                        return {};
+                    }).then(function (data) {
+                        var message = data && data.message ? data.message : (i18n.copyError || 'Error');
+                        throw new Error(message);
+                    });
+                }
+                var contentType = response.headers.get('content-type') || '';
+                if (contentType.indexOf('application/json') !== -1) {
+                    return response.json();
+                }
+                return response.text();
+            });
+        }
+
+        function loadState() {
+            uiState.loading = true;
+            render();
+            apiFetch('linkbuilder/state')
+                .then(function (data) {
+                    uiState.appState = data || {};
+                    syncUiWithState();
+                    uiState.loading = false;
+                    render();
+                })
+                .catch(function (error) {
+                    uiState.loading = false;
+                    setNotice(error.message || (i18n.copyError || 'Error'), 'error');
+                    render();
+                });
+        }
+
+        function syncUiWithState() {
+            var state = uiState.appState || {};
+            uiState.canonicalInput = state.canonical || uiState.canonicalInput || '';
+            uiState.madreSelection = state.madre_id || null;
+            uiState.madreAnchorsPreview = state.madre_anchors || [];
+            uiState.hijasSelection = Array.isArray(state.hijas_ids) ? state.hijas_ids.slice() : [];
+            uiState.nietasSelection = Array.isArray(state.nietas_ids) ? state.nietas_ids.slice() : [];
+
+            if (state.q_madre) {
+                uiState.searches.madre.keyword = state.q_madre;
+            }
+            uiState.searches.madre.includeBody = !!state.in_content_madre;
+
+            if (state.q_hijas) {
+                uiState.searches.hijas.keyword = state.q_hijas;
+            }
+            uiState.searches.hijas.includeBody = !!state.in_content_hijas;
+
+            if (state.q_nietas) {
+                uiState.searches.nietas.keyword = state.q_nietas;
+            }
+            uiState.searches.nietas.includeBody = !!state.in_content_nietas;
+        }
+
+        function canAccessStep(step) {
+            var state = uiState.appState || {};
+            if (step <= 1) {
+                return true;
+            }
+            if (!state.madre_id) {
+                return false;
+            }
+            if (step === 2) {
+                return true;
+            }
+            if (step === 3) {
+                return Array.isArray(state.hijas_ids) && state.hijas_ids.length > 0;
+            }
+            if (step === 4) {
+                return Array.isArray(state.nietas_ids) && state.nietas_ids.length > 0;
+            }
+            return false;
+        }
+
+        function goToStep(step) {
+            step = parseInt(step, 10);
+            if (isNaN(step) || step < 1 || step > 4) {
+                return;
+            }
+            if (!canAccessStep(step)) {
+                setNotice(i18n.missingMadre || 'Completa el paso anterior.', 'error');
+                render();
+                return;
+            }
+            uiState.currentStep = step;
+            updateUrlStep(step);
+            clearNotice();
+            render();
+        }
+
+        function performSearch(step, page) {
+            var search = uiState.searches[step];
+            if (!search) {
+                return;
+            }
+
+            if (!search.keyword) {
+                setNotice(i18n.keywordLabel || 'Introduce una palabra clave.', 'error');
+                render();
+                return;
+            }
+
+            var state = uiState.appState || {};
+            if (step !== 'madre' && !state.madre_id) {
+                setNotice(i18n.missingMadre || 'Selecciona una madre antes de continuar.', 'error');
+                render();
+                return;
+            }
+
+            search.page = page || 1;
+            uiState.loading = true;
+            render();
+
+            var params = new URLSearchParams();
+            params.append('kw', search.keyword);
+            params.append('page', search.page);
+            params.append('in_body', search.includeBody ? 1 : 0);
+
+            if (step !== 'madre') {
+                params.append('context_id', state.madre_id);
+                params.append('canonical', state.canonical || uiState.canonicalInput || '');
+                var exclude = [];
+                if (state.madre_id) {
+                    exclude.push(state.madre_id);
+                }
+                if (Array.isArray(state.hijas_ids)) {
+                    exclude = exclude.concat(state.hijas_ids);
+                }
+                if (Array.isArray(state.nietas_ids)) {
+                    exclude = exclude.concat(state.nietas_ids);
+                }
+                var unique = {};
+                exclude.forEach(function (id) {
+                    if (id) {
+                        unique[id] = true;
+                    }
+                });
+                Object.keys(unique).forEach(function (id) {
+                    params.append('exclude[]', id);
+                });
+            }
+
+            apiFetch('search?' + params.toString())
+                .then(function (data) {
+                    search.items = data.items || [];
+                    search.total = data.total || 0;
+                    search.totalPages = data.totalPages || 0;
+                    search.hasSearched = true;
+                    uiState.loading = false;
+                    clearNotice();
+                    render();
+                })
+                .catch(function (error) {
+                    uiState.loading = false;
+                    setNotice(error.message || (i18n.copyError || 'Error'), 'error');
+                    render();
+                });
+        }
+
+        function saveMadre() {
+            var selected = uiState.madreSelection;
+            if (!selected) {
+                setNotice(i18n.missingMadre || 'Selecciona una madre antes de continuar.', 'error');
+                render();
+                return;
+            }
+            var canonical = (uiState.canonicalInput || '').trim();
+            if (!canonical) {
+                canonical = (search.keyword || '').trim();
+            }
+
+            if (!canonical) {
+                setNotice(i18n.keywordLabel || 'Introduce una palabra clave.', 'error');
+                render();
+                return;
+            }
+
+            uiState.canonicalInput = canonical;
+
+            uiState.loading = true;
+            render();
+
+            var search = uiState.searches.madre;
+            var payload = {
+                id: selected,
+                canonical: canonical,
+                keyword: search.keyword || canonical,
+                in_content: search.includeBody ? 1 : 0,
+            };
+
+            apiFetch('linkbuilder/madre', {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            })
+                .then(function (data) {
+                    uiState.appState = data.state || {};
+                    uiState.madreAnchorsPreview = (data.anchors && data.anchors.anchors) || [];
+                    syncUiWithState();
+                    uiState.loading = false;
+                    clearNotice();
+                    goToStep(2);
+                })
+                .catch(function (error) {
+                    uiState.loading = false;
+                    setNotice(error.message || (i18n.copyError || 'Error'), 'error');
+                    render();
+                });
+        }
+
+        function saveHijas() {
+            var state = uiState.appState || {};
+            var limit = state.limit_hijas || 1;
+            var selection = uiState.hijasSelection || [];
+            if (selection.length === 0) {
+                setNotice(i18n.missingHijas || 'Selecciona al menos una hija.', 'error');
+                render();
+                return;
+            }
+            if (selection.length > limit) {
+                setNotice(i18n.limitExceeded || 'Has superado el límite.', 'error');
+                render();
+                return;
+            }
+
+            uiState.loading = true;
+            render();
+
+            var search = uiState.searches.hijas;
+            var payload = {
+                ids: selection,
+                keyword: search.keyword || '',
+                in_content: search.includeBody ? 1 : 0,
+            };
+
+            apiFetch('linkbuilder/hijas', {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            })
+                .then(function (data) {
+                    uiState.appState = data.state || {};
+                    uiState.hijasSelection = (data.state && data.state.hijas_ids) ? data.state.hijas_ids.slice() : [];
+                    uiState.loading = false;
+                    clearNotice();
+                    goToStep(3);
+                })
+                .catch(function (error) {
+                    uiState.loading = false;
+                    setNotice(error.message || (i18n.copyError || 'Error'), 'error');
+                    render();
+                });
+        }
+
+        function saveNietas() {
+            var state = uiState.appState || {};
+            var limit = state.limit_nietas || 1;
+            var selection = uiState.nietasSelection || [];
+            if (selection.length === 0) {
+                setNotice(i18n.missingNietas || 'Selecciona al menos una nieta.', 'error');
+                render();
+                return;
+            }
+            if (selection.length > limit) {
+                setNotice(i18n.limitExceeded || 'Has superado el límite.', 'error');
+                render();
+                return;
+            }
+
+            uiState.loading = true;
+            render();
+
+            var search = uiState.searches.nietas;
+            var payload = {
+                ids: selection,
+                keyword: search.keyword || '',
+                in_content: search.includeBody ? 1 : 0,
+            };
+
+            apiFetch('linkbuilder/nietas', {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            })
+                .then(function (data) {
+                    uiState.appState = data || {};
+                    uiState.nietasSelection = Array.isArray(data.nietas_ids) ? data.nietas_ids.slice() : [];
+                    uiState.loading = false;
+                    clearNotice();
+                    goToStep(4);
+                })
+                .catch(function (error) {
+                    uiState.loading = false;
+                    setNotice(error.message || (i18n.copyError || 'Error'), 'error');
+                    render();
+                });
+        }
+
+        function resetFlow() {
+            uiState.loading = true;
+            render();
+            apiFetch('linkbuilder/reset', { method: 'POST' })
+                .then(function (data) {
+                    uiState.appState = data || {};
+                    uiState.searches.madre = searchDefault();
+                    uiState.searches.hijas = searchDefault();
+                    uiState.searches.nietas = searchDefault();
+                    uiState.currentStep = 1;
+                    uiState.canonicalInput = '';
+                    uiState.madreSelection = null;
+                    uiState.madreAnchorsPreview = [];
+                    uiState.hijasSelection = [];
+                    uiState.nietasSelection = [];
+                    uiState.loading = false;
+                    clearNotice();
+                    updateUrlStep(1);
+                    render();
+                })
+                .catch(function (error) {
+                    uiState.loading = false;
+                    setNotice(error.message || (i18n.copyError || 'Error'), 'error');
+                    render();
+                });
+        }
+
+        function exportCsv() {
+            uiState.loading = true;
+            render();
+            apiFetch('linkbuilder/export')
+                .then(function (data) {
+                    uiState.loading = false;
+                    clearNotice();
+                    if (!data || !data.csv) {
+                        setNotice(i18n.exportError || 'No se pudo generar el CSV.', 'error');
+                        render();
+                        return;
+                    }
+                    var blob = new Blob([data.csv], { type: 'text/csv;charset=utf-8;' });
+                    var link = document.createElement('a');
+                    link.href = URL.createObjectURL(blob);
+                    link.download = data.filename || 'anchors.csv';
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                    setNotice(i18n.csvGenerated || 'CSV generado.', 'success');
+                    render();
+                })
+                .catch(function (error) {
+                    uiState.loading = false;
+                    setNotice(error.message || (i18n.exportError || 'No se pudo generar el CSV.'), 'error');
+                    render();
+                });
+        }
+
+        function render() {
+            var html = '';
+            html += '<div class="sai-lb-header">';
+            html += renderNav();
+            html += '<div class="sai-lb-actions">';
+            html += '<button type="button" class="button" data-action="reset-flow"' + (uiState.loading ? ' disabled' : '') + '>' + escapeHtml(i18n.reset || 'Reiniciar flujo') + '</button>';
+            html += '</div>';
+            html += '</div>';
+
+            if (uiState.notice) {
+                var noticeClass = uiState.noticeType === 'error' ? 'sai-notice-error' : 'sai-notice-success';
+                html += '<div class="sai-notice ' + noticeClass + '">' + escapeHtml(uiState.notice) + '</div>';
+            }
+
+            if (uiState.loading) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+            }
+
+            html += '<div class="sai-lb-step-content">' + renderStepContent() + '</div>';
+
+            container.innerHTML = html;
+
+            if (!eventsBound) {
+                bindEvents();
+                eventsBound = true;
+            }
+        }
+
+        function renderNav() {
+            var steps = [
+                { id: 1, label: i18n.madreHeading || 'Paso 1' },
+                { id: 2, label: i18n.hijasHeading || 'Paso 2' },
+                { id: 3, label: i18n.nietasHeading || 'Paso 3' },
+                { id: 4, label: i18n.exportHeading || 'Paso 4' },
+            ];
+            var html = '<ul class="sai-lb-steps">';
+            steps.forEach(function (step) {
+                var classes = ['sai-lb-step-item'];
+                if (uiState.currentStep === step.id) {
+                    classes.push('is-active');
+                }
+                if (!canAccessStep(step.id)) {
+                    classes.push('is-disabled');
+                }
+                html += '<li class="' + classes.join(' ') + '" data-step="' + step.id + '">' + escapeHtml(step.label) + '</li>';
+            });
+            html += '</ul>';
+            return html;
+        }
+
+        function renderStepContent() {
+            switch (uiState.currentStep) {
+                case 1:
+                    return renderStepMadre();
+                case 2:
+                    return renderStepHijas();
+                case 3:
+                    return renderStepNietas();
+                case 4:
+                    return renderStepExport();
+                default:
+                    return '';
+            }
+        }
+
+        function renderSearchControls(stepKey, label, showCanonical) {
+            var search = uiState.searches[stepKey];
+            var html = '<div class="sai-search">';
+            html += '<div class="sai-search-controls">';
+            html += '<label class="sai-label">' + escapeHtml(i18n.keywordLabel || 'Palabra clave') + '<input type="text" data-input="keyword" data-step="' + stepKey + '" value="' + escapeHtml(search.keyword) + '" placeholder="' + escapeHtml(i18n.keywordLabel || '') + '"></label>';
+            html += '<div class="sai-search-actions">';
+            html += '<label class="sai-checkbox"><input type="checkbox" data-input="include" data-step="' + stepKey + '"' + (search.includeBody ? ' checked' : '') + '> ' + escapeHtml(i18n.includeBody || '') + '</label>';
+            html += '<button type="button" class="button button-primary" data-action="search" data-step="' + stepKey + '">' + escapeHtml(i18n.search || 'Buscar') + '</button>';
+            html += '</div>';
+            html += '</div>';
+
+            if (showCanonical) {
+                html += '<div class="sai-canonical-field">';
+                html += '<label class="sai-label">' + escapeHtml(i18n.canonical || 'Canónico') + '<input type="text" data-input="canonical" value="' + escapeHtml(uiState.canonicalInput || search.keyword || '') + '"></label>';
+                html += '</div>';
+            }
+
+            html += '</div>';
+            return html;
+        }
+
+        function renderPagination(stepKey) {
+            var search = uiState.searches[stepKey];
+            if (!search || search.totalPages <= 1) {
+                return '';
+            }
+            var html = '<div class="sai-pagination">';
+            html += '<button type="button" class="button" data-action="page-prev" data-step="' + stepKey + '"' + (search.page <= 1 ? ' disabled' : '') + '>&laquo;</button>';
+            html += '<span>' + escapeHtml((i18n.pageLabel || 'Página') + ' ' + search.page + ' / ' + search.totalPages) + '</span>';
+            html += '<button type="button" class="button" data-action="page-next" data-step="' + stepKey + '"' + (search.page >= search.totalPages ? ' disabled' : '') + '>&raquo;</button>';
+            html += '</div>';
+            return html;
+        }
+
+        function renderStepMadre() {
+            var search = uiState.searches.madre;
+            var state = uiState.appState || {};
+            var html = '<h2>' + escapeHtml(i18n.madreHeading || 'Paso 1: Selecciona la madre') + '</h2>';
+            html += renderSearchControls('madre', i18n.madreHeading, true);
+            html += '<div class="sai-results">';
+            if (uiState.loading && search.items.length === 0) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+            } else if (search.hasSearched && search.items.length === 0) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.noResults || 'Sin resultados.') + '</p>';
+            } else {
+                html += '<table class="widefat fixed">';
+                html += '<thead><tr><th></th><th>' + escapeHtml(i18n.keywordLabel || 'Título') + '</th><th>' + escapeHtml(i18n.view || 'Ver') + '</th></tr></thead>';
+                html += '<tbody>';
+                search.items.forEach(function (item) {
+                    html += '<tr>';
+                    html += '<td><input type="radio" name="madre-select" data-action="select-madre" value="' + item.id + '"' + (uiState.madreSelection === item.id ? ' checked' : '') + '></td>';
+                    html += '<td><strong>' + escapeHtml(item.title) + '</strong><br><span class="sai-result-meta">' + escapeHtml(item.type) + '</span></td>';
+                    html += '<td><a href="' + escapeHtml(item.link) + '" class="button" target="_blank" rel="noopener noreferrer">' + escapeHtml(i18n.view || 'Ver') + '</a></td>';
+                    html += '</tr>';
+                });
+                html += '</tbody></table>';
+            }
+            html += '</div>';
+            html += renderPagination('madre');
+
+            html += '<div class="sai-step-actions">';
+            html += '<button type="button" class="button button-primary" data-action="save-madre"' + (uiState.loading ? ' disabled' : '') + '>' + escapeHtml(i18n.saveMadre || 'Guardar madre y continuar') + '</button>';
+            html += '</div>';
+
+            if (state.madre_id) {
+                html += '<div class="sai-summary">';
+                html += '<h3>' + escapeHtml(i18n.madreAnchors || 'Anchors de la madre') + '</h3>';
+                if (uiState.madreAnchorsPreview.length) {
+                    html += '<ul class="sai-anchor-list">';
+                    uiState.madreAnchorsPreview.forEach(function (anchor) {
+                        html += '<li><strong>' + escapeHtml(anchor.text) + '</strong> <span class="sai-tag">' + escapeHtml(anchor.class) + '</span> <span class="sai-tag">' + escapeHtml(anchor.frequency) + '</span></li>';
+                    });
+                    html += '</ul>';
+                } else {
+                    html += '<p class="sai-status">' + escapeHtml(i18n.noAnchors || 'No hay anchors disponibles.') + '</p>';
+                }
+                html += '</div>';
+            }
+
+            return html;
+        }
+
+        function renderStepHijas() {
+            var search = uiState.searches.hijas;
+            var state = uiState.appState || {};
+            var limit = state.limit_hijas || 1;
+            var html = '<h2>' + escapeHtml(i18n.hijasHeading || 'Paso 2: Selecciona las hijas') + '</h2>';
+            html += '<p class="sai-status">' + escapeHtml((i18n.selectionLimit || 'Límite de selección') + ': ' + limit) + '</p>';
+            html += renderSearchControls('hijas', i18n.hijasHeading, false);
+            html += '<div class="sai-results">';
+            if (uiState.loading && search.items.length === 0) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+            } else if (search.hasSearched && search.items.length === 0) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.noResults || 'Sin resultados.') + '</p>';
+            } else {
+                html += '<table class="widefat fixed">';
+                html += '<thead><tr><th></th><th>' + escapeHtml(i18n.keywordLabel || 'Título') + '</th><th>' + escapeHtml(i18n.cannibalHeading || 'Canibalización') + '</th><th>' + escapeHtml(i18n.view || 'Ver') + '</th></tr></thead>';
+                html += '<tbody>';
+                search.items.forEach(function (item) {
+                    var checked = uiState.hijasSelection.indexOf(item.id) !== -1 ? ' checked' : '';
+                    var cannibal = item.cannibalization || {};
+                    html += '<tr>';
+                    html += '<td><input type="checkbox" data-action="select-hija" value="' + item.id + '"' + checked + '></td>';
+                    html += '<td><strong>' + escapeHtml(item.title) + '</strong><br><span class="sai-result-meta">' + escapeHtml(item.type) + '</span></td>';
+                    html += '<td>' + renderCannibalBadge(cannibal) + '</td>';
+                    html += '<td><a href="' + escapeHtml(item.link) + '" class="button" target="_blank" rel="noopener noreferrer">' + escapeHtml(i18n.view || 'Ver') + '</a></td>';
+                    html += '</tr>';
+                });
+                html += '</tbody></table>';
+            }
+            html += '</div>';
+            html += renderPagination('hijas');
+
+            html += '<div class="sai-step-actions">';
+            html += '<span>' + escapeHtml((i18n.selected || 'Seleccionados') + ': ' + uiState.hijasSelection.length) + '</span>';
+            html += '<button type="button" class="button button-primary" data-action="save-hijas"' + (uiState.loading ? ' disabled' : '') + '>' + escapeHtml(i18n.saveHijas || 'Guardar hijas y continuar') + '</button>';
+            html += '</div>';
+
+            if (state.hijas_ids && state.hijas_ids.length) {
+                html += '<div class="sai-summary">';
+                html += '<h3>' + escapeHtml(i18n.hijaAnchors || 'Anchors por hija') + '</h3>';
+                state.hijas_ids.forEach(function (id) {
+                    var anchors = state.hijas_anchors && state.hijas_anchors[id] ? state.hijas_anchors[id] : [];
+                    html += '<div class="sai-summary-card">';
+                    html += '<strong>' + escapeHtml('ID: ' + id) + ' · ' + escapeHtml((anchors.length || 0) + ' anchors') + '</strong>';
+                    if (anchors.length) {
+                        html += '<ul class="sai-anchor-list">';
+                        anchors.forEach(function (anchor) {
+                            html += '<li><strong>' + escapeHtml(anchor.text) + '</strong> <span class="sai-tag">' + escapeHtml(anchor.class) + '</span> <span class="sai-tag">' + escapeHtml(anchor.frequency) + '</span></li>';
+                        });
+                        html += '</ul>';
+                    } else {
+                        html += '<p class="sai-status">' + escapeHtml(i18n.noAnchors || 'No hay anchors disponibles.') + '</p>';
+                    }
+                    html += '</div>';
+                });
+                html += '</div>';
+            }
+
+            return html;
+        }
+
+        function renderStepNietas() {
+            var search = uiState.searches.nietas;
+            var state = uiState.appState || {};
+            var limit = state.limit_nietas || 1;
+            var html = '<h2>' + escapeHtml(i18n.nietasHeading || 'Paso 3: Selecciona las nietas') + '</h2>';
+            html += '<p class="sai-status">' + escapeHtml((i18n.selectionLimit || 'Límite de selección') + ': ' + limit) + '</p>';
+            html += renderSearchControls('nietas', i18n.nietasHeading, false);
+            html += '<div class="sai-results">';
+            if (uiState.loading && search.items.length === 0) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.loading || 'Cargando...') + '</p>';
+            } else if (search.hasSearched && search.items.length === 0) {
+                html += '<p class="sai-status">' + escapeHtml(i18n.noResults || 'Sin resultados.') + '</p>';
+            } else {
+                html += '<table class="widefat fixed">';
+                html += '<thead><tr><th></th><th>' + escapeHtml(i18n.keywordLabel || 'Título') + '</th><th>' + escapeHtml(i18n.cannibalHeading || 'Canibalización') + '</th><th>' + escapeHtml(i18n.view || 'Ver') + '</th></tr></thead>';
+                html += '<tbody>';
+                search.items.forEach(function (item) {
+                    var checked = uiState.nietasSelection.indexOf(item.id) !== -1 ? ' checked' : '';
+                    var cannibal = item.cannibalization || {};
+                    html += '<tr>';
+                    html += '<td><input type="checkbox" data-action="select-nieta" value="' + item.id + '"' + checked + '></td>';
+                    html += '<td><strong>' + escapeHtml(item.title) + '</strong><br><span class="sai-result-meta">' + escapeHtml(item.type) + '</span></td>';
+                    html += '<td>' + renderCannibalBadge(cannibal) + '</td>';
+                    html += '<td><a href="' + escapeHtml(item.link) + '" class="button" target="_blank" rel="noopener noreferrer">' + escapeHtml(i18n.view || 'Ver') + '</a></td>';
+                    html += '</tr>';
+                });
+                html += '</tbody></table>';
+            }
+            html += '</div>';
+            html += renderPagination('nietas');
+
+            html += '<div class="sai-step-actions">';
+            html += '<span>' + escapeHtml((i18n.selected || 'Seleccionados') + ': ' + uiState.nietasSelection.length) + '</span>';
+            html += '<button type="button" class="button button-primary" data-action="save-nietas"' + (uiState.loading ? ' disabled' : '') + '>' + escapeHtml(i18n.saveNietas || 'Guardar nietas y continuar') + '</button>';
+            html += '</div>';
+
+            return html;
+        }
+
+        function renderStepExport() {
+            var state = uiState.appState || {};
+            var madreAnchors = state.madre_anchors || [];
+            var hijas = state.hijas_ids || [];
+            var nietas = state.nietas_ids || [];
+            var hijasAnchors = state.hijas_anchors || {};
+            var totalHijaAnchors = 0;
+            Object.keys(hijasAnchors).forEach(function (key) {
+                if (Array.isArray(hijasAnchors[key])) {
+                    totalHijaAnchors += hijasAnchors[key].length;
+                }
+            });
+
+            var html = '<h2>' + escapeHtml(i18n.exportHeading || 'Paso 4: Exportar CSV') + '</h2>';
+            html += '<div class="sai-summary">';
+            html += '<p><strong>' + escapeHtml('Madre') + ':</strong> ' + escapeHtml(state.madre_id || '-') + ' · ' + escapeHtml((i18n.madreAnchors || 'Anchors de la madre') + ': ' + madreAnchors.length) + '</p>';
+            html += '<p><strong>' + escapeHtml('Hijas') + ':</strong> ' + escapeHtml(hijas.length) + ' · ' + escapeHtml('Anchors: ' + totalHijaAnchors) + '</p>';
+            html += '<p><strong>' + escapeHtml('Nietas') + ':</strong> ' + escapeHtml(nietas.length) + '</p>';
+            html += '</div>';
+
+            html += '<div class="sai-step-actions">';
+            html += '<button type="button" class="button button-primary" data-action="export-csv"' + (uiState.loading ? ' disabled' : '') + '>' + escapeHtml(i18n.exportCsv || 'Exportar CSV') + '</button>';
+            html += '</div>';
+
+            return html;
+        }
+
+        function renderCannibalBadge(cannibal) {
+            if (!cannibal || typeof cannibal !== 'object') {
+                return '<span class="sai-semaforo sai-semaforo--amarillo">0</span>';
+            }
+            var level = cannibal.level || 'amarillo';
+            var score = typeof cannibal.score === 'number' ? cannibal.score : 0;
+            var reasons = Array.isArray(cannibal.reasons) ? cannibal.reasons.join(', ') : '';
+            return '<span class="sai-semaforo sai-semaforo--' + level + '" title="' + escapeHtml(reasons) + '">' + escapeHtml(score) + '</span>';
+        }
+
+        function bindEvents() {
+            container.addEventListener('click', function (event) {
+                var target = event.target;
+                var action = target.getAttribute('data-action');
+                if (target.classList.contains('sai-lb-step-item')) {
+                    var step = parseInt(target.getAttribute('data-step'), 10);
+                    if (!isNaN(step)) {
+                        goToStep(step);
+                    }
+                    return;
+                }
+                if (!action) {
+                    return;
+                }
+                if (action === 'search') {
+                    var stepKey = target.getAttribute('data-step');
+                    performSearch(stepKey, 1);
+                } else if (action === 'page-prev' || action === 'page-next') {
+                    var step = target.getAttribute('data-step');
+                    var search = uiState.searches[step];
+                    if (!search) {
+                        return;
+                    }
+                    var page = search.page || 1;
+                    if (action === 'page-prev' && page > 1) {
+                        performSearch(step, page - 1);
+                    }
+                    if (action === 'page-next' && page < search.totalPages) {
+                        performSearch(step, page + 1);
+                    }
+                } else if (action === 'save-madre') {
+                    saveMadre();
+                } else if (action === 'save-hijas') {
+                    saveHijas();
+                } else if (action === 'save-nietas') {
+                    saveNietas();
+                } else if (action === 'reset-flow') {
+                    resetFlow();
+                } else if (action === 'export-csv') {
+                    exportCsv();
+                }
+            });
+
+            container.addEventListener('change', function (event) {
+                var target = event.target;
+                var action = target.getAttribute('data-action');
+                var inputType = target.getAttribute('data-input');
+
+                if (inputType === 'keyword') {
+                    var stepKey = target.getAttribute('data-step');
+                    if (uiState.searches[stepKey]) {
+                        uiState.searches[stepKey].keyword = target.value.trim();
+                    }
+                } else if (inputType === 'include') {
+                    var includeStep = target.getAttribute('data-step');
+                    if (uiState.searches[includeStep]) {
+                        uiState.searches[includeStep].includeBody = target.checked;
+                    }
+                } else if (inputType === 'canonical') {
+                    uiState.canonicalInput = target.value;
+                }
+
+                if (action === 'select-madre') {
+                    uiState.madreSelection = parseInt(target.value, 10) || null;
+                } else if (action === 'select-hija') {
+                    toggleSelection(uiState.hijasSelection, parseInt(target.value, 10));
+                } else if (action === 'select-nieta') {
+                    toggleSelection(uiState.nietasSelection, parseInt(target.value, 10));
+                }
+            });
+
+            container.addEventListener('keydown', function (event) {
+                var target = event.target;
+                if (target.getAttribute('data-input') === 'keyword' && event.key === 'Enter') {
+                    event.preventDefault();
+                    var stepKey = target.getAttribute('data-step');
+                    performSearch(stepKey, 1);
+                }
+            });
+        }
+
+        function toggleSelection(list, value) {
+            if (!value) {
+                return;
+            }
+            var index = list.indexOf(value);
+            if (index === -1) {
+                list.push(value);
+            } else {
+                list.splice(index, 1);
+            }
+        }
+
+        loadState();
+        render();
+    });
+})();

--- a/includes/class-sai-anchors.php
+++ b/includes/class-sai-anchors.php
@@ -1,0 +1,1304 @@
+<?php
+/**
+ * Anchor extraction logic without AI.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SAI_Anchors {
+
+    /**
+     * List of Spanish stopwords.
+     *
+     * @var array
+     */
+    protected $stopwords = [
+        'a', 'acá', 'ahí', 'al', 'algo', 'algunas', 'algunos', 'allí', 'allá', 'ante', 'antes', 'aquel', 'aquella',
+        'aquellas', 'aquellos', 'aqui', 'aquí', 'arriba', 'así', 'atrás', 'bajo', 'bastante', 'bien', 'cada', 'casi',
+        'como', 'con', 'contra', 'cual', 'cuales', 'cualquier', 'cualquiera', 'cualquieras', 'cuando', 'cuanto',
+        'cuanta', 'cuantas', 'cuantos', 'de', 'dejar', 'del', 'demás', 'demasiada', 'demasiadas', 'demasiado',
+        'demasiados', 'dentro', 'desde', 'donde', 'dos', 'el', 'él', 'ella', 'ellas', 'ellos', 'en', 'encima', 'entonces',
+        'entre', 'era', 'erais', 'eran', 'eras', 'eres', 'es', 'esa', 'esas', 'ese', 'eso', 'esos', 'esta', 'está', 'estaba',
+        'estabais', 'estaban', 'estabas', 'estad', 'estada', 'estadas', 'estado', 'estados', 'estamos', 'estando',
+        'estar', 'estaremos', 'estará', 'estarán', 'estarás', 'estaré', 'estaréis', 'estaría', 'estaríais', 'estaríamos',
+        'estarían', 'estarías', 'estas', 'estás', 'este', 'esto', 'estos', 'estoy', 'fin', 'fue', 'fueron', 'fui', 'fuimos',
+        'ha', 'habéis', 'haber', 'habrá', 'habrán', 'habrás', 'habré', 'habréis', 'habría', 'habríais', 'habríamos',
+        'habrían', 'habrías', 'haciendo', 'hace', 'haces', 'hacia', 'haciendo', 'han', 'hasta', 'hay', 'haya', 'hayan',
+        'hayas', 'he', 'hemos', 'hube', 'hubiera', 'hubierais', 'hubieran', 'hubieras', 'hubieron', 'hubiese', 'hubieseis',
+        'hubiesen', 'hubieses', 'hubimos', 'hubiste', 'hubisteis', 'la', 'las', 'le', 'les', 'lo', 'los', 'mas', 'más', 'me',
+        'mi', 'mis', 'mucho', 'muchos', 'muy', 'nada', 'ni', 'no', 'nos', 'nosotras', 'nosotros', 'nuestra', 'nuestras',
+        'nuestro', 'nuestros', 'o', 'os', 'otra', 'otras', 'otro', 'otros', 'para', 'pero', 'poca', 'pocas', 'poco', 'pocos',
+        'por', 'porque', 'primero', 'puede', 'pueden', 'pues', 'que', 'qué', 'querer', 'quien', 'quienes', 'se', 'sea',
+        'seas', 'ser', 'será', 'serán', 'serás', 'seré', 'seréis', 'sería', 'seríais', 'seríamos', 'serían', 'serías',
+        'si', 'sí', 'siempre', 'siendo', 'sin', 'sobre', 'sois', 'solamente', 'solo', 'sólo', 'somos', 'son', 'soy', 'su',
+        'sus', 'tal', 'tales', 'también', 'tampoco', 'tan', 'tanta', 'tantas', 'tanto', 'tantos', 'te', 'tenemos', 'tener',
+        'tengo', 'ti', 'tiene', 'tienen', 'toda', 'todas', 'todavía', 'todo', 'todos', 'tu', 'tus', 'un', 'una', 'uno',
+        'unos', 'vosotras', 'vosotros', 'y', 'ya', 'yo'
+    ];
+
+    /**
+     * CTA or noisy terms to exclude.
+     *
+     * @var array
+     */
+    protected $cta_terms = [
+        'whatsapp', 'compra', 'comprar', 'cotiza', 'cotizar', 'precio', 'oferta', 'ofertas', 'promocion',
+        'promociones', 'promo', 'descuentos', 'clic', 'click', 'click aqui', 'haz clic', 'suscríbete', 'suscribete',
+        'registro', 'regístrate', 'registrate', 'teléfono', 'telefono', 'moldurama', 'mx', 'llámanos', 'llamanos',
+        'envíanos', 'envianos'
+    ];
+
+    /**
+     * Boilerplate phrases to discard.
+     *
+     * @var array
+     */
+    protected $boilerplate_phrases = [
+        'en definitiva', 'muchos casos', 'otro aspecto', 'en terminos generales', 'en términos generales',
+        'estas medidas'
+    ];
+
+    /**
+     * Patrones conversacionales/CTA a bloquear (sobre texto normalizado).
+     *
+     * @var array
+     */
+    protected $conversational_anchors_patterns = [
+        // querer
+        '/\\b(quiero|quieres|quiere|queremos|quieren|quisiera(s)?|querer|querria(s)?)\\b/u',
+        // necesitar
+        '/\\b(necesito|necesitas|necesita|necesitamos|necesitan|necesitar|necesitando|necesitaria(s)?)\\b/u',
+        // buscar
+        '/\\b(busc(o|as|a|amos|an)|buscar|buscando|busque|busquen)\\b/u',
+        // expresion "buscan un/una/el/la ..."
+        '/\\bbuscan\\s+(un|una|el|la)\\b/u',
+
+        // contactar / contacto (contáctanos -> "contactanos" al normalizar)
+        '/\\b(contact(ar|o|a|amos|an)|contactanos|contacto)\\b/u',
+        // llamar (llámanos -> "llamanos")
+        '/\\b(llam(ar|o|as|a|amos|an)|llamanos)\\b/u',
+        // escribir (escríbenos -> "escribenos")
+        '/\\b(escrib(ir|o|es|e|imos|en)|escribenos)\\b/u',
+
+        // solicitar / pedir
+        '/\\b(solicit(a|e|en|ar|ando)|pide|piden|pedir|pedido(s)?)\\b/u',
+        // cotizar / cotizacion
+        '/\\b(cotiza(r)?|cotiz(o|as|a|amos|an)|cotizacion(es)?)\\b/u',
+        // comprar
+        '/\\b(compra(r)?|compr(o|as|a|amos|an))\\b/u',
+
+        // frases CTA típicas
+        '/\\bsi\\s+(necesitas|buscas)\\b/u',
+        '/\\b(estoy|estas|esta|estamos|estan|están)\\s+(buscando|necesitando|queriendo)\\b/u',
+    ];
+
+    /**
+     * Low-value verbs to exclude when enforcing verb filters.
+     *
+     * @var array
+     */
+    protected $forbidden_verbs = [
+        'es', 'son', 'esta', 'está', 'estan', 'están', 'permite', 'permiten', 'permitir', 'ayuda', 'ayudan',
+        'ayudar', 'mejora', 'mejoran', 'mejorar', 'aumenta', 'aumentan', 'aumentar', 'resulta', 'resultan',
+        'resultar', 'reduce', 'reducen', 'reducir', 'contribuye', 'contribuyen', 'contribuir', 'representa',
+        'representan', 'representar', 'ofrece', 'ofrecen', 'ofrecer', 'utilizar', 'utiliza', 'utilizan',
+        'buscar', 'busca', 'buscas', 'buscan', 'buscamos', 'busco', 'buscando', 'buscado', 'busque', 'busquen'
+    ];
+
+    /**
+     * Connector or brand words for canonical core.
+     *
+     * @var array
+     */
+    protected $connector_words = [ 'mx', 'com', 'de', 'del', 'para', 'en' ];
+
+    /**
+     * Topic core terms that must appear in anchors.
+     *
+     * @var array
+     */
+    protected $core_terms = [ 'caseton', 'poliestireno', 'eps', 'unicel', 'losa', 'reticular', '40x40x20' ];
+
+    /**
+     * Base core terms used to seed dynamic topic detection.
+     *
+     * @var array
+     */
+    protected $core_terms_base = [
+        'poliestireno',
+        'eps',
+        'unicel',
+        'aislamiento',
+        'térmico',
+        'acústico',
+        'losa',
+        'reticular',
+        'nervada',
+        'entrepiso',
+        'techo',
+        'cubierta',
+        'hormigón',
+        'concreto',
+        'acero',
+        'vigueta',
+        'cimbra',
+        'densidad',
+        'humedad',
+        'eficiencia energética',
+        'transporte',
+        'durabilidad',
+    ];
+
+    /**
+     * Runtime core terms derived per request.
+     *
+     * @var array
+     */
+    protected $runtime_core_terms = [];
+
+    /**
+     * Optional title injected at runtime.
+     *
+     * @var string
+     */
+    public $request_title = '';
+
+    /**
+     * Returns stopwords list.
+     *
+     * @return array
+     */
+    public function get_stopwords() {
+        return $this->stopwords;
+    }
+
+    /**
+     * Normalizes text using internal rules.
+     *
+     * @param string $text Text to normalize.
+     * @return string
+     */
+    public function normalize_text( $text ) {
+        return $this->normalize( $text );
+    }
+
+    /**
+     * Returns the canonical core string.
+     *
+     * @param string $canonical Canonical phrase.
+     * @return string
+     */
+    public function get_canonical_core( $canonical ) {
+        return $this->canonical_core( $canonical );
+    }
+
+    /**
+     * Cleans raw content removing headings, scripts and HTML tags.
+     *
+     * @param string $content Raw HTML content.
+     * @return string Clean plain text.
+     */
+    public function clean_content( $content ) {
+        if ( empty( $content ) ) {
+            return '';
+        }
+
+        $content = preg_replace( '/<script[\s\S]*?<\/script>/i', ' ', $content );
+        $content = preg_replace( '/<style[\s\S]*?<\/style>/i', ' ', $content );
+        $content = preg_replace( '/<h[1-6][^>]*>[\s\S]*?<\/h[1-6]>/i', ' ', $content );
+        $content = strip_tags( $content );
+        $content = html_entity_decode( $content, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+        $content = preg_replace( '/\s+/u', ' ', $content );
+
+        return trim( $content );
+    }
+
+    /**
+     * Counts words in text.
+     *
+     * @param string $text Text to count.
+     * @return int
+     */
+    public function get_word_count( $text ) {
+        if ( empty( $text ) ) {
+            return 0;
+        }
+
+        $words = preg_split( '/[\s]+/u', trim( $text ) );
+        $words = array_filter( $words, 'strlen' );
+
+        return count( $words );
+    }
+
+    /**
+     * Extracts anchors and quotas.
+     *
+     * @param string $canonical Canonical keyword.
+     * @param string $body_text Clean body text.
+     * @return array
+     */
+    public function extract( $canonical, $body_text ) {
+        $this->runtime_core_terms = [];
+
+        $body_text = $this->prepare_text( $body_text );
+        $canonical = trim( (string) $canonical );
+
+        $word_count = $this->get_word_count( $body_text );
+        $presets    = $this->get_presets( $word_count );
+
+        if ( '' === $canonical ) {
+            return new WP_Error(
+                'sai_missing_canonical',
+                __( 'La palabra canónica es obligatoria.', 'anchors-sin-ia' ),
+                [
+                    'status'     => 400,
+                    'word_count' => $word_count,
+                ]
+            );
+        }
+
+        if ( '' === $body_text ) {
+            return new WP_Error(
+                'sai_empty_body',
+                __( 'El cuerpo del contenido está vacío tras la limpieza.', 'anchors-sin-ia' ),
+                [
+                    'status'     => 400,
+                    'word_count' => $word_count,
+                ]
+            );
+        }
+
+        $tokens = $this->tokenize_with_positions( $body_text );
+        if ( empty( $tokens ) ) {
+            return new WP_Error(
+                'sai_no_tokens',
+                __( 'No hay suficientes términos para generar anchors válidos.', 'anchors-sin-ia' ),
+                [
+                    'status'     => 400,
+                    'word_count' => $word_count,
+                ]
+            );
+        }
+
+        $canonical_norm      = $this->normalize( $canonical );
+        $canonical_core      = $this->canonical_core( $canonical );
+        $canonical_core_norm = $this->normalize( $canonical_core );
+
+        $maybe_title = '';
+        if ( property_exists( $this, 'request_title' ) ) {
+            $maybe_title = (string) $this->request_title;
+        }
+
+        $this->runtime_core_terms = $this->build_core_terms_dynamic( $canonical, $body_text, $maybe_title );
+
+        $rounds = [
+            [ 'min_window' => 2, 'max_window' => 7, 'min_frequency' => 2, 'enforce_verbs' => true ],
+            [ 'min_window' => 2, 'max_window' => 8, 'min_frequency' => 2, 'enforce_verbs' => true ],
+            [ 'min_window' => 2, 'max_window' => 8, 'min_frequency' => 1, 'enforce_verbs' => true ],
+            [ 'min_window' => 2, 'max_window' => 8, 'min_frequency' => 1, 'enforce_verbs' => false ],
+        ];
+
+        $candidates   = [];
+        $target_total = (int) $presets['total'];
+
+        foreach ( $rounds as $round ) {
+            $new_candidates = $this->collect_valid_candidates(
+                $tokens,
+                $body_text,
+                $canonical_norm,
+                $canonical_core_norm,
+                $round,
+                $candidates
+            );
+
+            $candidates = $this->merge_candidate_lists( $candidates, $new_candidates );
+
+            if ( empty( $candidates ) ) {
+                continue;
+            }
+
+            $deduped = $this->deduplicate_candidates( $candidates );
+
+            $grouped = [ 'exacta' => [], 'frase' => [], 'semantica' => [] ];
+            foreach ( $deduped as $candidate ) {
+                $grouped[ $candidate['classification'] ][] = $candidate;
+            }
+
+            $canonical_frequency = $this->count_frequency( $canonical, $body_text );
+            if ( $canonical_frequency > 0 && empty( $grouped['exacta'] ) ) {
+                $start_position = mb_strpos( $body_text, $canonical, 0, 'UTF-8' );
+                if ( false === $start_position ) {
+                    $start_position = PHP_INT_MAX;
+                }
+
+                $grouped['exacta'][] = [
+                    'text'           => $canonical,
+                    'classification' => 'exacta',
+                    'frequency'      => $canonical_frequency,
+                    'start'          => $start_position,
+                ];
+            }
+
+            foreach ( $grouped as &$items ) {
+                usort(
+                    $items,
+                    function ( $a, $b ) {
+                        if ( $a['frequency'] === $b['frequency'] ) {
+                            $len_compare = mb_strlen( $a['text'], 'UTF-8' ) <=> mb_strlen( $b['text'], 'UTF-8' );
+                            if ( 0 !== $len_compare ) {
+                                return $len_compare;
+                            }
+
+                            return ( $a['start'] ?? PHP_INT_MAX ) <=> ( $b['start'] ?? PHP_INT_MAX );
+                        }
+
+                        return $b['frequency'] <=> $a['frequency'];
+                    }
+                );
+            }
+            unset( $items );
+
+            $available_total = count( $grouped['exacta'] ) + count( $grouped['frase'] ) + count( $grouped['semantica'] );
+            if ( $available_total < $target_total ) {
+                continue;
+            }
+
+            $quotas  = $this->resolve_quotas( $presets, $grouped );
+            if ( is_wp_error( $quotas ) ) {
+                $this->runtime_core_terms = [];
+                return $quotas;
+            }
+            $anchors = $this->select_anchors( $grouped, $quotas );
+
+            if ( count( $anchors ) === $target_total ) {
+                $counts_actual = [ 'exacta' => 0, 'frase' => 0, 'semantica' => 0 ];
+                foreach ( $anchors as $anchor ) {
+                    if ( isset( $counts_actual[ $anchor['class'] ] ) ) {
+                        $counts_actual[ $anchor['class'] ]++;
+                    }
+                }
+                $result = [
+                    'word_count'      => $word_count,
+                    'suggested_total' => count( $anchors ),
+                    'quotas'          => [
+                        'total'     => count( $anchors ),
+                        'exacta'    => $counts_actual['exacta'],
+                        'frase'     => $counts_actual['frase'],
+                        'semantica' => $counts_actual['semantica'],
+                    ],
+                    'anchors'         => $anchors,
+                ];
+
+                $this->runtime_core_terms = [];
+
+                return $result;
+            }
+        }
+
+        $error = new WP_Error(
+            'sai_no_candidates',
+            __( 'No hay suficientes frases válidas para cubrir las cuotas SEO sin violar las reglas (exacta/frase/semántica).', 'anchors-sin-ia' ),
+            [
+                'status'     => 422,
+                'word_count' => $word_count,
+            ]
+        );
+
+        $this->runtime_core_terms = [];
+
+        return $error;
+    }
+
+    /**
+     * Prepares text by collapsing whitespace.
+     *
+     * @param string $text Text to prepare.
+     * @return string
+     */
+    protected function prepare_text( $text ) {
+        $text = (string) $text;
+        $text = preg_replace( '/\s+/u', ' ', $text );
+        return trim( $text );
+    }
+
+    /**
+     * Normalizes text to lowercase without accents.
+     *
+     * @param string $text Text to normalize.
+     * @return string
+     */
+    protected function normalize( $text ) {
+        $text = wp_strip_all_tags( $text );
+        $text = strtolower( $text );
+        $text = remove_accents( $text );
+        $text = preg_replace( '/[^\p{L}0-9\s]+/u', ' ', $text );
+        $text = preg_replace( '/\s+/u', ' ', $text );
+        return trim( $text );
+    }
+
+    /**
+     * Generates canonical core string.
+     *
+     * @param string $canonical Canonical keyword.
+     * @return string
+     */
+    protected function canonical_core( $canonical ) {
+        $tokens = preg_split( '/\s+/u', strtolower( remove_accents( $canonical ) ) );
+        $filtered = array_diff( $tokens, $this->connector_words );
+        $filtered = array_filter( $filtered );
+        return implode( ' ', $filtered );
+    }
+
+    /**
+     * Builds dynamic core terms using canonical, title and body context.
+     *
+     * @param string $canonical    Canonical keyword.
+     * @param string $context_text Body text context.
+     * @param string $maybe_title  Optional title text.
+     * @return array
+     */
+    protected function build_core_terms_dynamic( $canonical, $context_text, $maybe_title = '' ) {
+        $terms = [];
+
+        foreach ( $this->core_terms_base as $term ) {
+            $normalized = $this->normalize( $term );
+            if ( '' !== $normalized ) {
+                $terms[] = $normalized;
+            }
+        }
+
+        foreach ( $this->core_terms as $term ) {
+            $normalized = $this->normalize( $term );
+            if ( '' !== $normalized ) {
+                $terms[] = $normalized;
+            }
+        }
+
+        $canonical_norm = $this->normalize( $canonical );
+        if ( '' !== $canonical_norm ) {
+            $terms[] = $canonical_norm;
+        }
+
+        $canonical_core = $this->canonical_core( $canonical );
+        $canonical_core_norm = $this->normalize( $canonical_core );
+        if ( '' !== $canonical_core_norm ) {
+            $terms[] = $canonical_core_norm;
+
+            $core_tokens = preg_split( '/\s+/u', $canonical_core_norm );
+            foreach ( $core_tokens as $token ) {
+                if ( '' !== $token && ! in_array( $token, $this->stopwords, true ) ) {
+                    $terms[] = $token;
+                }
+            }
+        }
+
+        $title_source = trim( (string) $maybe_title );
+        if ( '' === $title_source ) {
+            $snippet_words = preg_split( '/\s+/u', trim( (string) $context_text ) );
+            if ( ! empty( $snippet_words ) ) {
+                $title_source = implode( ' ', array_slice( $snippet_words, 0, 12 ) );
+            }
+        }
+
+        if ( '' !== $title_source ) {
+            $title_norm    = $this->normalize( $title_source );
+            $title_tokens  = array_filter( preg_split( '/\s+/u', $title_norm ) );
+            foreach ( $title_tokens as $token ) {
+                if ( '' === $token || in_array( $token, $this->stopwords, true ) ) {
+                    continue;
+                }
+
+                $terms[] = $token;
+            }
+        }
+
+        $ngrams = $this->top_ngrams_from_text( $context_text, 1, 3, 12 );
+        foreach ( $ngrams as $ngram ) {
+            if ( '' !== $ngram ) {
+                $terms[] = $ngram;
+            }
+        }
+
+        $terms = array_filter(
+            $terms,
+            function ( $term ) {
+                return '' !== $term;
+            }
+        );
+
+        $terms = array_values( array_unique( $terms ) );
+
+        return $terms;
+    }
+
+    /**
+     * Extracts frequent n-grams from text to seed dynamic core terms.
+     *
+     * @param string $text   Text to analyze.
+     * @param int    $min_n  Minimum n-gram size.
+     * @param int    $max_n  Maximum n-gram size.
+     * @param int    $limit  Maximum n-grams to return.
+     * @return array
+     */
+    protected function top_ngrams_from_text( $text, $min_n = 1, $max_n = 3, $limit = 12 ) {
+        $text   = $this->prepare_text( $text );
+        $min_n  = max( 1, (int) $min_n );
+        $max_n  = max( $min_n, (int) $max_n );
+        $limit  = max( 1, (int) $limit );
+        $ngrams = [];
+
+        if ( '' === $text ) {
+            return [];
+        }
+
+        if ( ! preg_match_all( '/\b[\p{L}0-9][\p{L}0-9\p{Mn}\p{Pd}]*\b/u', $text, $matches ) ) {
+            return [];
+        }
+
+        $tokens = [];
+        foreach ( $matches[0] as $match ) {
+            $normalized = $this->normalize_token( $match );
+            if ( '' === $normalized ) {
+                continue;
+            }
+
+            $tokens[] = $normalized;
+        }
+
+        $token_count = count( $tokens );
+        if ( 0 === $token_count ) {
+            return [];
+        }
+
+        $candidates = [];
+
+        for ( $n = $min_n; $n <= $max_n; $n++ ) {
+            if ( $n > $token_count ) {
+                break;
+            }
+
+            for ( $i = 0; $i <= $token_count - $n; $i++ ) {
+                $slice = array_slice( $tokens, $i, $n );
+                if ( empty( $slice ) ) {
+                    continue;
+                }
+
+                $first = $slice[0];
+                $last  = $slice[ count( $slice ) - 1 ];
+
+                if ( in_array( $first, $this->stopwords, true ) || in_array( $last, $this->stopwords, true ) ) {
+                    continue;
+                }
+
+                $non_stop = 0;
+                foreach ( $slice as $token ) {
+                    if ( ! in_array( $token, $this->stopwords, true ) ) {
+                        $non_stop++;
+                    }
+                }
+
+                if ( $non_stop < 1 ) {
+                    continue;
+                }
+
+                $phrase = implode( ' ', $slice );
+
+                if ( '' === $phrase ) {
+                    continue;
+                }
+
+                if ( isset( $candidates[ $phrase ] ) ) {
+                    $candidates[ $phrase ]['frequency']++;
+                } else {
+                    $candidates[ $phrase ] = [
+                        'text'      => $phrase,
+                        'frequency' => 1,
+                        'length'    => mb_strlen( $phrase, 'UTF-8' ),
+                        'start'     => $i,
+                    ];
+                }
+            }
+        }
+
+        if ( empty( $candidates ) ) {
+            return [];
+        }
+
+        $items = array_values( $candidates );
+        usort(
+            $items,
+            function ( $a, $b ) {
+                if ( $a['frequency'] === $b['frequency'] ) {
+                    if ( $a['length'] === $b['length'] ) {
+                        return $a['start'] <=> $b['start'];
+                    }
+
+                    return $a['length'] <=> $b['length'];
+                }
+
+                return $b['frequency'] <=> $a['frequency'];
+            }
+        );
+
+        $items = array_slice( $items, 0, $limit );
+
+        return array_map(
+            function ( $item ) {
+                return $item['text'];
+            },
+            $items
+        );
+    }
+
+    /**
+     * Tokenizes text and keeps positions.
+     *
+     * @param string $text Clean text.
+     * @return array
+     */
+    protected function tokenize_with_positions( $text ) {
+        $tokens = [];
+        if ( '' === $text ) {
+            return $tokens;
+        }
+
+        if ( preg_match_all( '/\b[\p{L}0-9][\p{L}0-9\p{Mn}\p{Pd}]*\b/u', $text, $matches, PREG_OFFSET_CAPTURE ) ) {
+            foreach ( $matches[0] as $match ) {
+                $tokens[] = [
+                    'token'  => $match[0],
+                    'offset' => $match[1],
+                    'length' => mb_strlen( $match[0] ),
+                ];
+            }
+        }
+
+        return $tokens;
+    }
+
+    protected function char_pos_from_byte_offset( $text, $byte_offset ) {
+        return mb_strlen( substr( $text, 0, $byte_offset ), 'UTF-8' );
+    }
+
+    /**
+     * Generates candidate anchors from tokens.
+     *
+     * @param array  $tokens Tokens with positions.
+     * @param string $text   Full text.
+     * @return array
+     */
+    protected function generate_candidates( $tokens, $text, $min_window = 2, $max_window = 7 ) {
+        $candidates  = [];
+        $token_count = count( $tokens );
+
+        for ( $i = 0; $i < $token_count; $i++ ) {
+            for ( $window = $min_window; $window <= $max_window; $window++ ) {
+                $end_index = $i + $window - 1;
+                if ( $end_index >= $token_count ) {
+                    break;
+                }
+
+                // Offsets en bytes (de preg_match_all)
+                $start_byte = $tokens[ $i ]['offset'];
+                $end_token  = $tokens[ $end_index ];
+                $end_byte   = $end_token['offset'] + strlen( $end_token['token'] );
+
+                // Convertir a posiciones en caracteres (para mb_substr)
+                $start_char = $this->char_pos_from_byte_offset( $text, $start_byte );
+                $end_char   = $this->char_pos_from_byte_offset( $text, $end_byte );
+
+                $substr = mb_substr( $text, $start_char, $end_char - $start_char, 'UTF-8' );
+                $substr = $this->prepare_text( $substr );
+                $length = mb_strlen( $substr, 'UTF-8' );
+
+                if ( $length < 6 || $length > 80 ) {
+                    continue;
+                }
+
+                $candidates[] = [
+                    'text'   => $substr,
+                    'tokens' => array_slice( $tokens, $i, $window ),
+                    'start'  => $start_char,
+                ];
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * Validates candidate anchor.
+     *
+     * @param array  $candidate Candidate data.
+     * @param string $canonical_core_norm Normalized canonical core.
+     * @return bool
+     */
+    protected function is_candidate_valid( $candidate, $canonical_core_norm, $enforce_verbs = true ) {
+        $text = $candidate['text'];
+        $normalized = $this->normalize( $text );
+
+        if ( '' === $normalized ) {
+            return false;
+        }
+
+        if ( preg_match( "/[\\.,;:\"'()\\[\\]{}<>]/u", $text ) ) {
+            return false;
+        }
+
+        if ( false !== mb_strpos( $text, '“' ) || false !== mb_strpos( $text, '”' ) || false !== mb_strpos( $text, '«' ) || false !== mb_strpos( $text, '»' ) || false !== mb_strpos( $text, '—' ) || false !== mb_strpos( $text, '–' ) ) {
+            return false;
+        }
+
+        if ( false !== strpos( $text, '%' ) ) {
+            return false;
+        }
+
+        if ( preg_match( '/https?:\/\//i', $text ) || preg_match( '/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i', $text ) ) {
+            return false;
+        }
+
+        $tokens_norm = preg_split( '/\s+/u', $normalized );
+        $alpha_tokens = array_filter(
+            $tokens_norm,
+            function ( $token ) {
+                return (bool) preg_match( '/[a-z]/u', $token );
+            }
+        );
+
+        if ( count( $alpha_tokens ) < 2 ) {
+            return false;
+        }
+
+        $non_stop = array_filter(
+            $tokens_norm,
+            function ( $token ) {
+                return ! in_array( $token, $this->stopwords, true );
+            }
+        );
+
+        if ( count( $non_stop ) < 2 ) {
+            return false;
+        }
+
+        foreach ( $this->cta_terms as $term ) {
+            if ( false !== strpos( $normalized, $term ) ) {
+                return false;
+            }
+        }
+
+        foreach ( $this->boilerplate_phrases as $phrase ) {
+            if ( false !== strpos( $normalized, $phrase ) ) {
+                return false;
+            }
+        }
+
+        if ( preg_match( '/\b\d{2,}\b/', $text ) && preg_match( '/\b\d{7,}\b/', $text ) ) {
+            // Likely a phone number.
+            return false;
+        }
+
+        if ( preg_match( '/[\d\.,]+\s?(%|usd|mxn|eur|\$)/iu', $text ) ) {
+            return false;
+        }
+
+        if ( preg_match( '/\.[a-z]{2,}/iu', $text ) ) {
+            if ( preg_match( '/\b[a-z0-9.-]+\.(com|mx|net|org|biz|info|edu|gob)(?:\.[a-z]{2})?\b/iu', $text ) ) {
+                return false;
+            }
+        }
+
+        $first_token = $candidate['tokens'][0]['token'];
+        $last_token  = $candidate['tokens'][ count( $candidate['tokens'] ) - 1 ]['token'];
+        $first_norm  = $this->normalize_token( $first_token );
+        $last_norm   = $this->normalize_token( $last_token );
+
+        if ( '' === $first_norm || in_array( $first_norm, $this->stopwords, true ) ) {
+            return false;
+        }
+
+        if ( '' === $last_norm || in_array( $last_norm, $this->stopwords, true ) ) {
+            return false;
+        }
+
+        if ( $enforce_verbs ) {
+            foreach ( $tokens_norm as $token ) {
+                if ( in_array( $token, $this->forbidden_verbs, true ) ) {
+                    return false;
+                }
+            }
+        }
+
+        $core_terms = ! empty( $this->runtime_core_terms ) ? $this->runtime_core_terms : $this->core_terms;
+        $contains_core = false;
+        foreach ( $core_terms as $term ) {
+            $term_norm = $this->normalize( $term );
+            if ( '' === $term_norm ) {
+                continue;
+            }
+
+            if ( false !== mb_strpos( $normalized, $term_norm, 0, 'UTF-8' ) ) {
+                $contains_core = true;
+                break;
+            }
+        }
+
+        if ( ! $contains_core ) {
+            return false;
+        }
+
+        // Requerir intersección con el canónico o con core base (no el dinámico)
+        $contains_canonical_token = false;
+        if ( '' !== $canonical_core_norm ) {
+            $canonical_tokens = preg_split( '/\s+/u', $canonical_core_norm );
+            foreach ( $canonical_tokens as $core_token ) {
+                if ( '' !== $core_token && false !== strpos( $normalized, $core_token ) ) {
+                    $contains_canonical_token = true;
+                    break;
+                }
+            }
+        }
+
+        $contains_base_core = false;
+        foreach ( $this->core_terms as $term ) {
+            $term_norm = $this->normalize( $term );
+            if ( '' !== $term_norm && false !== mb_strpos( $normalized, $term_norm, 0, 'UTF-8' ) ) {
+                $contains_base_core = true;
+                break;
+            }
+        }
+
+        if ( ! $contains_canonical_token && ! $contains_base_core ) {
+            return false;
+        }
+
+        // Bloquear anchors conversacionales/CTA (sobre texto normalizado)
+        if ( ! empty( $this->conversational_anchors_patterns ) ) {
+            foreach ( $this->conversational_anchors_patterns as $re ) {
+                if ( preg_match( $re, $normalized ) ) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Collects valid candidates within a range of n-grams.
+     *
+     * @param array  $tokens Tokens with offsets.
+     * @param string $text   Body text.
+     * @param string $canonical_norm Normalized canonical.
+     * @param string $canonical_core_norm Normalized canonical core.
+     * @param array  $options  Extraction options (min_window, max_window, min_frequency, enforce_verbs).
+     * @param array  $existing Already accepted candidates.
+     * @return array
+     */
+    protected function collect_valid_candidates( $tokens, $text, $canonical_norm, $canonical_core_norm, $options, $existing = [] ) {
+        $min_window     = isset( $options['min_window'] ) ? max( 2, (int) $options['min_window'] ) : 2;
+        $max_window     = isset( $options['max_window'] ) ? max( $min_window, (int) $options['max_window'] ) : 7;
+        $min_frequency  = isset( $options['min_frequency'] ) ? max( 1, (int) $options['min_frequency'] ) : 1;
+        $enforce_verbs  = isset( $options['enforce_verbs'] ) ? (bool) $options['enforce_verbs'] : true;
+        $raw_candidates = $this->generate_candidates( $tokens, $text, $min_window, $max_window );
+
+        $existing_texts = [];
+        foreach ( $existing as $candidate ) {
+            if ( isset( $candidate['text'] ) ) {
+                $existing_texts[ $candidate['text'] ] = true;
+            }
+        }
+
+        $valid = [];
+
+        foreach ( $raw_candidates as $candidate ) {
+            if ( isset( $existing_texts[ $candidate['text'] ] ) ) {
+                continue;
+            }
+
+            if ( ! $this->is_candidate_valid( $candidate, $canonical_core_norm, $enforce_verbs ) ) {
+                continue;
+            }
+
+            $frequency = $this->count_frequency( $candidate['text'], $text );
+            if ( $frequency < $min_frequency ) {
+                continue;
+            }
+
+            $classification = $this->classify_candidate( $candidate['text'], $canonical_norm, $canonical_core_norm );
+            $candidate['classification'] = $classification;
+            $candidate['frequency']      = $frequency;
+            $valid[]                     = $candidate;
+            $existing_texts[ $candidate['text'] ] = true;
+        }
+
+        return $valid;
+    }
+
+    /**
+     * Merges candidate lists by text keeping the strongest frequency.
+     *
+     * @param array $primary Primary list.
+     * @param array $additional Additional list.
+     * @return array
+     */
+    protected function merge_candidate_lists( $primary, $additional ) {
+        if ( empty( $primary ) ) {
+            return $additional;
+        }
+
+        foreach ( $additional as $candidate ) {
+            $found = false;
+            foreach ( $primary as &$existing ) {
+                if ( $existing['text'] === $candidate['text'] ) {
+                    $found = true;
+                    if ( $candidate['frequency'] > $existing['frequency'] ) {
+                        $existing = $candidate;
+                    } elseif ( $candidate['frequency'] === $existing['frequency'] ) {
+                        $existing_length  = mb_strlen( $existing['text'], 'UTF-8' );
+                        $candidate_length = mb_strlen( $candidate['text'], 'UTF-8' );
+
+                        if ( $candidate_length < $existing_length ) {
+                            $existing = $candidate;
+                        } elseif ( $candidate_length === $existing_length ) {
+                            $existing_start  = $existing['start'] ?? PHP_INT_MAX;
+                            $candidate_start = $candidate['start'] ?? PHP_INT_MAX;
+
+                            if ( $candidate_start < $existing_start ) {
+                                $existing = $candidate;
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+            unset( $existing );
+
+            if ( ! $found ) {
+                $primary[] = $candidate;
+            }
+        }
+
+        return $primary;
+    }
+
+    /**
+     * Classifies candidate anchor.
+     *
+     * @param string $anchor_text Anchor.
+     * @param string $canonical_norm Normalized canonical string.
+     * @param string $canonical_core_norm Normalized canonical core string.
+     * @return string
+     */
+    protected function classify_candidate( $anchor_text, $canonical_norm, $canonical_core_norm ) {
+        $anchor_norm = $this->normalize( $anchor_text );
+
+        if ( '' !== $canonical_norm && $anchor_norm === $canonical_norm ) {
+            return 'exacta';
+        }
+
+        if ( '' !== $canonical_core_norm && $anchor_norm === $canonical_core_norm ) {
+            return 'exacta';
+        }
+
+        if ( '' !== $canonical_norm && false !== strpos( $anchor_norm, $canonical_norm ) ) {
+            return 'frase';
+        }
+
+        if ( '' !== $canonical_core_norm && false !== strpos( $anchor_norm, $canonical_core_norm ) ) {
+            return 'frase';
+        }
+
+        return 'semantica';
+    }
+
+    /**
+     * Counts frequency of anchor using strict word boundaries on original text.
+     *
+     * @param string $anchor_text Anchor text.
+     * @param string $text        Body text.
+     * @return int
+     */
+    protected function count_frequency( $anchor_text, $text ) {
+        $anchor_text = $this->prepare_text( $anchor_text );
+        if ( '' === $anchor_text || '' === $text ) {
+            return 0;
+        }
+
+        $pattern = '/(?<![\p{L}\p{N}])' . preg_quote( $anchor_text, '/' ) . '(?![\p{L}\p{N}])/u';
+        $matches = preg_match_all( $pattern, $text, $results );
+        if ( false !== $matches && $matches > 0 ) {
+            return (int) $matches;
+        }
+
+        $fallback = substr_count( $text, $anchor_text );
+        return (int) $fallback;
+    }
+
+    /**
+     * Removes duplicates based on signature.
+     *
+     * @param array $candidates Candidate anchors.
+     * @return array
+     */
+    protected function deduplicate_candidates( $candidates ) {
+        $signatures = [];
+
+        foreach ( $candidates as $candidate ) {
+            $tokens = preg_split( '/\s+/u', $this->normalize( $candidate['text'] ) );
+            $signature_tokens = [];
+            foreach ( $tokens as $token ) {
+                if ( '' === $token || in_array( $token, $this->stopwords, true ) ) {
+                    continue;
+                }
+                $signature_tokens[] = $token;
+            }
+            $signature = implode( ' ', $signature_tokens );
+            if ( '' === $signature ) {
+                $signature = $this->normalize( $candidate['text'] );
+            }
+
+            if ( isset( $signatures[ $signature ] ) ) {
+                $existing = $signatures[ $signature ];
+                if ( $candidate['frequency'] > $existing['frequency'] ) {
+                    $signatures[ $signature ] = $candidate;
+                } elseif ( $candidate['frequency'] === $existing['frequency'] ) {
+                    $existing_length  = mb_strlen( $existing['text'], 'UTF-8' );
+                    $candidate_length = mb_strlen( $candidate['text'], 'UTF-8' );
+
+                    if ( $candidate_length < $existing_length ) {
+                        $signatures[ $signature ] = $candidate;
+                    } elseif ( $candidate_length === $existing_length ) {
+                        $existing_start  = $existing['start'] ?? PHP_INT_MAX;
+                        $candidate_start = $candidate['start'] ?? PHP_INT_MAX;
+
+                        if ( $candidate_start < $existing_start ) {
+                            $signatures[ $signature ] = $candidate;
+                        }
+                    }
+                }
+            } else {
+                $signatures[ $signature ] = $candidate;
+            }
+        }
+
+        return array_values( $signatures );
+    }
+
+    /**
+     * Resolves quotas enforcing preset counts without reassignments.
+     *
+     * @param array $presets Base presets.
+     * @param array $grouped Candidates grouped by class.
+     * @return array
+     */
+    /**
+     * Resuelve cuotas con fallback elástico:
+     * - Intenta cubrir las cuotas preset por tipo.
+     * - Si falta alguna (p.ej. "frase"), rellena con otras clases disponibles,
+     *   priorizando: frase <- semantica <- exacta, hasta alcanzar el total preset.
+     * - Si aun así no se llega al total, devuelve WP_Error.
+     *
+     * @param array $presets  Base presets (total, exacta, frase, semantica).
+     * @param array $grouped  Candidatos agrupados por clase.
+     * @return array|WP_Error Cuotas finales por clase.
+     */
+    /**
+     * Resuelve cuotas con fallback elástico:
+     * - Intenta cubrir las cuotas preset por tipo.
+     * - Si falta alguna (p.ej. "frase"), rellena con otras clases disponibles,
+     *   priorizando: frase <- semantica <- exacta, hasta alcanzar el total preset.
+     * - Si aun así no se llega al total, devuelve WP_Error.
+     *
+     * @param array $presets  Base presets (total, exacta, frase, semantica).
+     * @param array $grouped  Candidatos agrupados por clase.
+     * @return array|WP_Error Cuotas finales por clase.
+     */
+    protected function resolve_quotas( $presets, $grouped ) {
+        $available = [
+            'exacta'    => isset( $grouped['exacta'] ) ? count( $grouped['exacta'] ) : 0,
+            'frase'     => isset( $grouped['frase'] ) ? count( $grouped['frase'] ) : 0,
+            'semantica' => isset( $grouped['semantica'] ) ? count( $grouped['semantica'] ) : 0,
+        ];
+
+        $need = [
+            'total'     => (int) $presets['total'],
+            'exacta'    => (int) $presets['exacta'],
+            'frase'     => (int) $presets['frase'],
+            'semantica' => (int) $presets['semantica'],
+        ];
+
+        // Paso 1: asignación base limitada por disponibilidad.
+        $quotas = [
+            'exacta'    => min( $need['exacta'], $available['exacta'] ),
+            'frase'     => min( $need['frase'], $available['frase'] ),
+            'semantica' => min( $need['semantica'], $available['semantica'] ),
+        ];
+
+        $assigned = $quotas['exacta'] + $quotas['frase'] + $quotas['semantica'];
+
+        if ( $assigned >= $need['total'] ) {
+            return $quotas;
+        }
+
+        // Preferencias para compensar déficits.
+        $order_fill = [
+            'frase'     => [ 'semantica', 'exacta' ],
+            'semantica' => [ 'frase', 'exacta' ],
+            'exacta'    => [ 'frase', 'semantica' ],
+        ];
+
+        // Excedentes disponibles por clase:
+        $surplus = [
+            'exacta'    => max( 0, $available['exacta'] - $quotas['exacta'] ),
+            'frase'     => max( 0, $available['frase'] - $quotas['frase'] ),
+            'semantica' => max( 0, $available['semantica'] - $quotas['semantica'] ),
+        ];
+
+        // Paso 2: intentar cumplir cuotas objetivo por clase usando excedentes de otras.
+        foreach ( [ 'frase', 'semantica', 'exacta' ] as $target ) {
+            while ( $assigned < $need['total'] && $quotas[ $target ] < $need[ $target ] ) {
+                $filled = false;
+                foreach ( $order_fill[ $target ] as $src ) {
+                    if ( $surplus[ $src ] > 0 ) {
+                        $surplus[ $src ]--;
+                        $quotas[ $target ]++;
+                        $assigned++;
+                        $filled = true;
+                        break;
+                    }
+                }
+                if ( ! $filled ) {
+                    break;
+                }
+            }
+        }
+
+        // Paso 3: si aún falta para el total, añadir con lo que quede (prioridad SEO: frase -> semantica -> exacta).
+        foreach ( [ 'frase', 'semantica', 'exacta' ] as $src ) {
+            while ( $assigned < $need['total'] && $surplus[ $src ] > 0 ) {
+                $surplus[ $src ]--;
+                $quotas[ $src ]++;
+                $assigned++;
+            }
+        }
+
+        if ( $assigned < $need['total'] ) {
+            return new WP_Error(
+                'sai_quota_deficit',
+                sprintf(
+                    __( 'No se pueden cubrir las cuotas SEO: total necesario %d, candidatos disponibles %d', 'anchors-sin-ia' ),
+                    $need['total'],
+                    $assigned
+                ),
+                [
+                    'status'     => 422,
+                    'need'       => $need,
+                    'available'  => $available,
+                    'assigned'   => $quotas,
+                ]
+            );
+        }
+
+        return $quotas;
+    }
+
+    /**
+     * Selects anchors according to resolved quotas.
+     *
+     * @param array $grouped Grouped candidates.
+     * @param array $quotas  Final quotas per class.
+     * @return array
+     */
+    protected function select_anchors( $grouped, $quotas ) {
+        $order    = [ 'exacta', 'frase', 'semantica' ];
+        $selected = [];
+
+        foreach ( $order as $type ) {
+            if ( empty( $quotas[ $type ] ) || empty( $grouped[ $type ] ) ) {
+                continue;
+            }
+
+            $slice    = array_slice( $grouped[ $type ], 0, (int) $quotas[ $type ] );
+            $selected = array_merge( $selected, $slice );
+        }
+
+        $order_map = [ 'exacta' => 0, 'frase' => 1, 'semantica' => 2 ];
+        usort(
+            $selected,
+            function ( $a, $b ) use ( $order_map ) {
+                $class_cmp = $order_map[ $a['classification'] ] <=> $order_map[ $b['classification'] ];
+                if ( 0 !== $class_cmp ) {
+                    return $class_cmp;
+                }
+
+                if ( $a['frequency'] === $b['frequency'] ) {
+                    $len_compare = mb_strlen( $a['text'], 'UTF-8' ) <=> mb_strlen( $b['text'], 'UTF-8' );
+                    if ( 0 !== $len_compare ) {
+                        return $len_compare;
+                    }
+
+                    return ( $a['start'] ?? PHP_INT_MAX ) <=> ( $b['start'] ?? PHP_INT_MAX );
+                }
+
+                return $b['frequency'] <=> $a['frequency'];
+            }
+        );
+
+        return array_map(
+            function ( $item ) {
+                return [
+                    'text'      => $item['text'],
+                    'class'     => $item['classification'],
+                    'frequency' => (int) $item['frequency'],
+                ];
+            },
+            $selected
+        );
+    }
+
+    /**
+     * Normalizes token for edge validation.
+     *
+     * @param string $token Token text.
+     * @return string
+     */
+    protected function normalize_token( $token ) {
+        $token = strtolower( remove_accents( $token ) );
+        $token = preg_replace( '/[^\p{L}0-9]+/u', '', $token );
+        return trim( $token );
+    }
+
+    /**
+     * Calculates presets based on word count.
+     *
+     * @param int $word_count Number of words.
+     * @return array
+     */
+    public function get_presets( $word_count ) {
+        if ( $word_count <= 700 ) {
+            return [
+                'total'     => 4,
+                'exacta'    => 1,
+                'frase'     => 1,
+                'semantica' => 2,
+            ];
+        }
+
+        if ( $word_count <= 1500 ) {
+            return [
+                'total'     => 6,
+                'exacta'    => 1,
+                'frase'     => 3,
+                'semantica' => 2,
+            ];
+        }
+
+        return [
+            'total'     => 8,
+            'exacta'    => 1,
+            'frase'     => 4,
+            'semantica' => 3,
+        ];
+    }
+}

--- a/includes/class-sai-rest.php
+++ b/includes/class-sai-rest.php
@@ -1,0 +1,581 @@
+<?php
+/**
+ * REST controller for Anchors sin IA.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SAI_REST_Controller {
+
+    /**
+     * Namespace.
+     */
+    const REST_NAMESPACE = 'anchors/v1';
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+    }
+
+    /**
+     * Registers routes.
+     */
+    public function register_routes() {
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/search',
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'handle_search' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+                'args'                => [
+                    'kw'      => [
+                        'type'     => 'string',
+                        'required' => true,
+                    ],
+                    'in_body' => [
+                        'type'              => 'integer',
+                        'required'          => false,
+                        'default'           => 0,
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'page'    => [
+                        'type'              => 'integer',
+                        'required'          => false,
+                        'default'           => 1,
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'exclude' => [
+                        'type'     => 'array',
+                        'required' => false,
+                    ],
+                    'context_id' => [
+                        'type'              => 'integer',
+                        'required'          => false,
+                        'default'           => 0,
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'canonical' => [
+                        'type'     => 'string',
+                        'required' => false,
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/post/(?P<id>\d+)',
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'handle_get_post' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+                'args'                => [
+                    'id' => [
+                        'type'              => 'integer',
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/extract',
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'handle_extract' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+                'args'                => [
+                    'id'        => [
+                        'type'              => 'integer',
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'canonical' => [
+                        'type'     => 'string',
+                        'required' => true,
+                    ],
+                    'body_text' => [
+                        'type'     => 'string',
+                        'required' => true,
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/linkbuilder/state',
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'handle_lb_get_state' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/linkbuilder/reset',
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'handle_lb_reset' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/linkbuilder/madre',
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'handle_lb_set_madre' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+                'args'                => [
+                    'id'        => [
+                        'type'              => 'integer',
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ],
+                    'canonical' => [
+                        'type'     => 'string',
+                        'required' => true,
+                    ],
+                    'keyword'   => [
+                        'type'     => 'string',
+                        'required' => false,
+                    ],
+                    'in_content' => [
+                        'type'              => 'integer',
+                        'required'          => false,
+                        'default'           => 0,
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/linkbuilder/hijas',
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'handle_lb_set_hijas' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+                'args'                => [
+                    'ids'        => [
+                        'type'     => 'array',
+                        'required' => true,
+                    ],
+                    'keyword'    => [
+                        'type'     => 'string',
+                        'required' => false,
+                    ],
+                    'in_content' => [
+                        'type'              => 'integer',
+                        'required'          => false,
+                        'default'           => 0,
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/linkbuilder/nietas',
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'handle_lb_set_nietas' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+                'args'                => [
+                    'ids'        => [
+                        'type'     => 'array',
+                        'required' => true,
+                    ],
+                    'keyword'    => [
+                        'type'     => 'string',
+                        'required' => false,
+                    ],
+                    'in_content' => [
+                        'type'              => 'integer',
+                        'required'          => false,
+                        'default'           => 0,
+                        'sanitize_callback' => 'absint',
+                    ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            self::REST_NAMESPACE,
+            '/linkbuilder/export',
+            [
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => [ $this, 'handle_lb_export' ],
+                'permission_callback' => [ $this, 'permission_check' ],
+            ]
+        );
+    }
+
+    /**
+     * Permission callback.
+     *
+     * @return bool
+     */
+    public function permission_check() {
+        return current_user_can( 'edit_posts' );
+    }
+
+    /**
+     * Handles search endpoint.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response
+     */
+    public function handle_search( WP_REST_Request $request ) {
+        $keyword = trim( (string) $request->get_param( 'kw' ) );
+        if ( '' === $keyword ) {
+            return rest_ensure_response(
+                [
+                    'items'      => [],
+                    'total'      => 0,
+                    'totalPages' => 0,
+                ]
+            );
+        }
+
+        $in_body    = (bool) $request->get_param( 'in_body' );
+        $page       = max( 1, (int) $request->get_param( 'page' ) );
+        $exclude    = $request->get_param( 'exclude' );
+        $context_id = (int) $request->get_param( 'context_id' );
+        $canonical  = sanitize_text_field( (string) $request->get_param( 'canonical' ) );
+
+        $args = [
+            'post_type'           => [ 'post', 'page' ],
+            'post_status'         => 'publish',
+            'posts_per_page'      => 50,
+            'paged'               => $page,
+            's'                   => $keyword,
+            'ignore_sticky_posts' => true,
+        ];
+
+        if ( ! $in_body ) {
+            $args['search_columns'] = [ 'post_title' ];
+        } else {
+            $args['search_columns'] = [ 'post_title', 'post_content' ];
+        }
+
+        if ( ! empty( $exclude ) && is_array( $exclude ) ) {
+            $args['post__not_in'] = array_map( 'absint', $exclude );
+        }
+
+        $query = new WP_Query( $args );
+
+        $items = [];
+        foreach ( $query->posts as $post ) {
+            $cannibal = null;
+            if ( $context_id && $canonical ) {
+                $cannibal = sai_lb_cannibal_score( $post->ID, $context_id, $canonical );
+            }
+            $items[] = [
+                'id'    => $post->ID,
+                'title' => get_the_title( $post ),
+                'type'  => $post->post_type,
+                'link'  => get_permalink( $post ),
+                'cannibalization' => $cannibal,
+            ];
+        }
+
+        wp_reset_postdata();
+
+        return rest_ensure_response(
+            [
+                'items'      => $items,
+                'total'      => (int) $query->found_posts,
+                'totalPages' => (int) $query->max_num_pages,
+            ]
+        );
+    }
+
+    /**
+     * Returns post detail without headings.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response
+     */
+    public function handle_get_post( WP_REST_Request $request ) {
+        $post_id = (int) $request['id'];
+        $post    = get_post( $post_id );
+
+        if ( ! $post || ! in_array( $post->post_type, [ 'post', 'page' ], true ) || 'publish' !== $post->post_status ) {
+            return new WP_Error( 'sai_not_found', __( 'Entrada no encontrada.', 'anchors-sin-ia' ), [ 'status' => 404 ] );
+        }
+
+        $anchors = new SAI_Anchors();
+        $content = get_post_field( 'post_content', $post );
+        $content = strip_shortcodes( $content );
+        $clean   = $anchors->clean_content( $content );
+        $words   = $anchors->get_word_count( $clean );
+
+        return rest_ensure_response(
+            [
+                'id'         => $post->ID,
+                'title'      => get_the_title( $post ),
+                'body_text'  => $clean,
+                'word_count' => $words,
+            ]
+        );
+    }
+
+    /**
+     * Handles extraction endpoint.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response
+     */
+    public function handle_extract( WP_REST_Request $request ) {
+        $id        = (int) $request->get_param( 'id' );
+        $canonical = sanitize_text_field( $request->get_param( 'canonical' ) );
+        $body_text = (string) $request->get_param( 'body_text' );
+
+        $post = get_post( $id );
+        if ( ! $post || ! in_array( $post->post_type, [ 'post', 'page' ], true ) ) {
+            return new WP_Error( 'sai_not_found', __( 'Entrada no encontrada.', 'anchors-sin-ia' ), [ 'status' => 404 ] );
+        }
+
+        $anchors = new SAI_Anchors();
+        $clean   = $anchors->clean_content( $body_text );
+        if ( '' === $clean ) {
+            $clean = $anchors->clean_content( get_post_field( 'post_content', $post ) );
+        }
+
+        $result = $anchors->extract( $canonical, $clean );
+
+        return rest_ensure_response( $result );
+    }
+
+    /**
+     * Returns stored linkbuilder state.
+     *
+     * @return WP_REST_Response
+     */
+    public function handle_lb_get_state() {
+        return rest_ensure_response( sai_lb_get_user_state() );
+    }
+
+    /**
+     * Resets linkbuilder state.
+     *
+     * @return WP_REST_Response
+     */
+    public function handle_lb_reset() {
+        sai_lb_reset_state();
+
+        return rest_ensure_response( sai_lb_get_user_state() );
+    }
+
+    /**
+     * Stores madre selection and extracts anchors.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handle_lb_set_madre( WP_REST_Request $request ) {
+        $madre_id  = (int) $request->get_param( 'id' );
+        $canonical = sanitize_text_field( $request->get_param( 'canonical' ) );
+        $keyword   = sanitize_text_field( (string) $request->get_param( 'keyword' ) );
+        $in_body   = (int) $request->get_param( 'in_content' );
+
+        if ( ! $madre_id || '' === $canonical ) {
+            return new WP_Error( 'sai_invalid_madre', __( 'Datos incompletos para la madre.', 'anchors-sin-ia' ), [ 'status' => 400 ] );
+        }
+
+        $post = get_post( $madre_id );
+        if ( ! $post || ! in_array( $post->post_type, [ 'post', 'page' ], true ) ) {
+            return new WP_Error( 'sai_not_found', __( 'Entrada no encontrada.', 'anchors-sin-ia' ), [ 'status' => 404 ] );
+        }
+
+        $plain    = sai_lb_post_plain_text( $madre_id );
+        $anchors  = new SAI_Anchors();
+        $anchors->request_title = get_the_title( $post );
+        $result   = $anchors->extract( $canonical, $plain );
+
+        if ( is_wp_error( $result ) ) {
+            return $result;
+        }
+
+        $state = sai_lb_update_state(
+            [
+                'q_madre'           => $keyword,
+                'in_content_madre'  => $in_body,
+                'madre_id'          => $madre_id,
+                'canonical'         => $canonical,
+                'madre_anchors'     => isset( $result['anchors'] ) ? $result['anchors'] : [],
+                'limit_hijas'       => max( 1, isset( $result['anchors'] ) ? count( $result['anchors'] ) : 0 ),
+                'hijas_ids'         => [],
+                'hijas_anchors'     => [],
+                'limit_nietas'      => 1,
+                'nietas_ids'        => [],
+                'q_hijas'           => '',
+                'in_content_hijas'  => 0,
+                'q_nietas'          => '',
+                'in_content_nietas' => 0,
+            ]
+        );
+
+        return rest_ensure_response(
+            [
+                'state'   => $state,
+                'anchors' => $result,
+            ]
+        );
+    }
+
+    /**
+     * Stores hijas selection and extracts anchors.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handle_lb_set_hijas( WP_REST_Request $request ) {
+        $ids       = $request->get_param( 'ids' );
+        $keyword   = sanitize_text_field( (string) $request->get_param( 'keyword' ) );
+        $in_body   = (int) $request->get_param( 'in_content' );
+        $state     = sai_lb_get_user_state();
+        $madre_id  = isset( $state['madre_id'] ) ? (int) $state['madre_id'] : 0;
+        $canonical = isset( $state['canonical'] ) ? $state['canonical'] : '';
+
+        if ( ! $madre_id || '' === $canonical ) {
+            return new WP_Error( 'sai_missing_madre', __( 'Selecciona una madre antes de elegir hijas.', 'anchors-sin-ia' ), [ 'status' => 400 ] );
+        }
+
+        if ( ! is_array( $ids ) ) {
+            $ids = [];
+        }
+
+        $ids = array_values( array_unique( array_map( 'absint', $ids ) ) );
+        $ids = array_filter( $ids, function ( $id ) use ( $madre_id ) {
+            return $id && $id !== $madre_id;
+        } );
+
+        $limit = isset( $state['limit_hijas'] ) ? (int) $state['limit_hijas'] : 1;
+        if ( count( $ids ) > $limit ) {
+            return new WP_Error( 'sai_limit_hijas', __( 'Has superado el límite de hijas permitido.', 'anchors-sin-ia' ), [ 'status' => 400 ] );
+        }
+
+        $anchors_map      = [];
+        $total_anchor_sum = 0;
+
+        foreach ( $ids as $id ) {
+            $post = get_post( $id );
+            if ( ! $post || ! in_array( $post->post_type, [ 'post', 'page' ], true ) ) {
+                return new WP_Error( 'sai_not_found', __( 'Entrada no encontrada.', 'anchors-sin-ia' ), [ 'status' => 404 ] );
+            }
+
+            $plain    = sai_lb_post_plain_text( $id );
+            $anchors  = new SAI_Anchors();
+            $anchors->request_title = get_the_title( $post );
+            $result   = $anchors->extract( $canonical, $plain );
+
+            if ( is_wp_error( $result ) ) {
+                return $result;
+            }
+
+            $anchor_list           = isset( $result['anchors'] ) ? $result['anchors'] : [];
+            $anchors_map[ $id ]    = $anchor_list;
+            $total_anchor_sum     += count( $anchor_list );
+        }
+
+        $limit_nietas = max( 1, $total_anchor_sum );
+
+        $state = sai_lb_update_state(
+            [
+                'q_hijas'           => $keyword,
+                'in_content_hijas'  => $in_body,
+                'hijas_ids'         => $ids,
+                'hijas_anchors'     => $anchors_map,
+                'limit_nietas'      => $limit_nietas,
+                'nietas_ids'        => [],
+                'q_nietas'          => '',
+                'in_content_nietas' => 0,
+            ]
+        );
+
+        return rest_ensure_response(
+            [
+                'state'   => $state,
+                'anchors' => $anchors_map,
+            ]
+        );
+    }
+
+    /**
+     * Stores nietas selection.
+     *
+     * @param WP_REST_Request $request Request.
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handle_lb_set_nietas( WP_REST_Request $request ) {
+        $ids      = $request->get_param( 'ids' );
+        $keyword  = sanitize_text_field( (string) $request->get_param( 'keyword' ) );
+        $in_body  = (int) $request->get_param( 'in_content' );
+        $state    = sai_lb_get_user_state();
+        $madre_id = isset( $state['madre_id'] ) ? (int) $state['madre_id'] : 0;
+        $hijas    = isset( $state['hijas_ids'] ) ? $state['hijas_ids'] : [];
+
+        if ( ! $madre_id || empty( $hijas ) ) {
+            return new WP_Error( 'sai_missing_hijas', __( 'Selecciona hijas antes de definir las nietas.', 'anchors-sin-ia' ), [ 'status' => 400 ] );
+        }
+
+        if ( ! is_array( $ids ) ) {
+            $ids = [];
+        }
+
+        $ids = array_values( array_unique( array_map( 'absint', $ids ) ) );
+        $ids = array_filter( $ids, function ( $id ) use ( $madre_id, $hijas ) {
+            return $id && $id !== $madre_id && ! in_array( $id, $hijas, true );
+        } );
+
+        $limit = isset( $state['limit_nietas'] ) ? (int) $state['limit_nietas'] : 1;
+        if ( count( $ids ) > $limit ) {
+            return new WP_Error( 'sai_limit_nietas', __( 'Has superado el límite de nietas permitido.', 'anchors-sin-ia' ), [ 'status' => 400 ] );
+        }
+
+        $state = sai_lb_update_state(
+            [
+                'q_nietas'          => $keyword,
+                'in_content_nietas' => $in_body,
+                'nietas_ids'        => $ids,
+            ]
+        );
+
+        return rest_ensure_response( $state );
+    }
+
+    /**
+     * Generates CSV export for the current selection.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function handle_lb_export() {
+        $state = sai_lb_get_user_state();
+
+        if ( empty( $state['madre_id'] ) ) {
+            return new WP_Error( 'sai_missing_madre', __( 'No hay madre seleccionada para exportar.', 'anchors-sin-ia' ), [ 'status' => 400 ] );
+        }
+
+        $export = sai_lb_generate_csv_data( $state );
+
+        if ( is_wp_error( $export ) ) {
+            return $export;
+        }
+
+        return rest_ensure_response( $export );
+    }
+}

--- a/includes/linkbuilder-helpers.php
+++ b/includes/linkbuilder-helpers.php
@@ -1,0 +1,686 @@
+<?php
+/**
+ * Helper functions for Linkbuilder workflow.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Returns the transient key for the current user state.
+ *
+ * @param int $user_id User ID.
+ * @return string
+ */
+function sai_lb_state_key( $user_id ) {
+    return 'sai_lb_state_' . absint( $user_id );
+}
+
+/**
+ * Returns the default state structure.
+ *
+ * @return array
+ */
+function sai_lb_default_state() {
+    return [
+        'q_madre'           => '',
+        'in_content_madre'  => 0,
+        'madre_id'          => 0,
+        'canonical'         => '',
+        'madre_anchors'     => [],
+        'limit_hijas'       => 1,
+        'q_hijas'           => '',
+        'in_content_hijas'  => 0,
+        'hijas_ids'         => [],
+        'hijas_anchors'     => [],
+        'limit_nietas'      => 1,
+        'q_nietas'          => '',
+        'in_content_nietas' => 0,
+        'nietas_ids'        => [],
+    ];
+}
+
+/**
+ * Retrieves the stored state for the current user.
+ *
+ * @return array
+ */
+function sai_lb_get_user_state() {
+    $user_id = get_current_user_id();
+    if ( ! $user_id ) {
+        return sai_lb_default_state();
+    }
+
+    $key   = sai_lb_state_key( $user_id );
+    $state = get_transient( $key );
+
+    if ( ! is_array( $state ) ) {
+        $state = sai_lb_default_state();
+    }
+
+    return wp_parse_args( $state, sai_lb_default_state() );
+}
+
+/**
+ * Saves the state for the current user.
+ *
+ * @param array $state State data.
+ * @return void
+ */
+function sai_lb_save_user_state( $state ) {
+    $user_id = get_current_user_id();
+    if ( ! $user_id ) {
+        return;
+    }
+
+    set_transient( sai_lb_state_key( $user_id ), $state, DAY_IN_SECONDS );
+}
+
+/**
+ * Updates the stored state with provided data.
+ *
+ * @param array $updates Partial updates.
+ * @return array Updated state.
+ */
+function sai_lb_update_state( $updates ) {
+    $state = sai_lb_get_user_state();
+    foreach ( $updates as $key => $value ) {
+        $state[ $key ] = $value;
+    }
+
+    sai_lb_save_user_state( $state );
+
+    return $state;
+}
+
+/**
+ * Resets the stored state.
+ *
+ * @return void
+ */
+function sai_lb_reset_state() {
+    $user_id = get_current_user_id();
+    if ( ! $user_id ) {
+        return;
+    }
+
+    delete_transient( sai_lb_state_key( $user_id ) );
+}
+
+/**
+ * Retrieves or builds cached analysis data for a post.
+ *
+ * @param int $post_id Post ID.
+ * @return array
+ */
+function sai_lb_get_post_analysis( $post_id ) {
+    $post_id = absint( $post_id );
+    if ( ! $post_id ) {
+        return [ 'plain' => '', 'vector' => [], 'top_ngrams' => [] ];
+    }
+
+    $cache_key = 'sai_lb_vec_' . $post_id;
+    $cached    = get_transient( $cache_key );
+    if ( is_array( $cached ) && isset( $cached['plain'] ) ) {
+        return $cached;
+    }
+
+    $anchors = new SAI_Anchors();
+    $content = get_post_field( 'post_content', $post_id );
+    $plain   = $anchors->clean_content( $content );
+
+    $analysis = [
+        'plain'      => $plain,
+        'vector'     => sai_lb_vectorize( $plain ),
+        'top_ngrams' => sai_lb_top_ngrams( $plain ),
+    ];
+
+    set_transient( $cache_key, $analysis, DAY_IN_SECONDS );
+
+    return $analysis;
+}
+
+/**
+ * Returns plain text body for a post using cached analysis.
+ *
+ * @param int $post_id Post ID.
+ * @return string
+ */
+function sai_lb_post_plain_text( $post_id ) {
+    $analysis = sai_lb_get_post_analysis( $post_id );
+    return isset( $analysis['plain'] ) ? $analysis['plain'] : '';
+}
+
+/**
+ * Normalizes text for vectorization.
+ *
+ * @param string $text Text to normalize.
+ * @return string
+ */
+function sai_lb_normalize_for_vector( $text ) {
+    $text = remove_accents( mb_strtolower( (string) $text, 'UTF-8' ) );
+    $text = preg_replace( '/[^a-z0-9\sx]/u', ' ', $text );
+    $text = preg_replace( '/\s+/u', ' ', $text );
+
+    return trim( $text );
+}
+
+/**
+ * Returns Spanish stopwords from the anchor extractor.
+ *
+ * @return array
+ */
+function sai_lb_stopwords() {
+    static $stopwords = null;
+    if ( null === $stopwords ) {
+        $anchors   = new SAI_Anchors();
+        $stopwords = $anchors->get_stopwords();
+    }
+
+    return $stopwords;
+}
+
+/**
+ * Vectorizes a plain text string into token frequencies.
+ *
+ * @param string $plain Plain text.
+ * @return array
+ */
+function sai_lb_vectorize( $plain ) {
+    $normalized = sai_lb_normalize_for_vector( $plain );
+    if ( '' === $normalized ) {
+        return [];
+    }
+
+    $tokens    = preg_split( '/\s+/u', $normalized );
+    $stopwords = sai_lb_stopwords();
+    $vector    = [];
+
+    foreach ( $tokens as $token ) {
+        if ( '' === $token || in_array( $token, $stopwords, true ) ) {
+            continue;
+        }
+
+        if ( mb_strlen( $token, 'UTF-8' ) < 3 ) {
+            continue;
+        }
+
+        if ( ! isset( $vector[ $token ] ) ) {
+            $vector[ $token ] = 0;
+        }
+
+        $vector[ $token ]++;
+    }
+
+    return $vector;
+}
+
+/**
+ * Calculates cosine similarity between vectors.
+ *
+ * @param array $v1 Vector 1.
+ * @param array $v2 Vector 2.
+ * @return float
+ */
+function sai_lb_cosine( $v1, $v2 ) {
+    if ( empty( $v1 ) || empty( $v2 ) ) {
+        return 0.0;
+    }
+
+    $dot = 0.0;
+    foreach ( $v1 as $token => $count ) {
+        if ( isset( $v2[ $token ] ) ) {
+            $dot += $count * $v2[ $token ];
+        }
+    }
+
+    if ( 0.0 === $dot ) {
+        return 0.0;
+    }
+
+    $mag1 = 0.0;
+    foreach ( $v1 as $count ) {
+        $mag1 += pow( $count, 2 );
+    }
+
+    $mag2 = 0.0;
+    foreach ( $v2 as $count ) {
+        $mag2 += pow( $count, 2 );
+    }
+
+    if ( 0.0 === $mag1 || 0.0 === $mag2 ) {
+        return 0.0;
+    }
+
+    return $dot / ( sqrt( $mag1 ) * sqrt( $mag2 ) );
+}
+
+/**
+ * Builds top n-grams from plain text.
+ *
+ * @param string $plain Plain text.
+ * @param int    $min   Minimum n.
+ * @param int    $max   Maximum n.
+ * @param int    $k     Limit of phrases.
+ * @return array
+ */
+function sai_lb_top_ngrams( $plain, $min = 2, $max = 3, $k = 20 ) {
+    $normalized = sai_lb_normalize_for_vector( $plain );
+    if ( '' === $normalized ) {
+        return [];
+    }
+
+    $tokens    = preg_split( '/\s+/u', $normalized );
+    $stopwords = sai_lb_stopwords();
+    $ngrams    = [];
+    $total     = count( $tokens );
+
+    for ( $i = 0; $i < $total; $i++ ) {
+        for ( $n = $min; $n <= $max; $n++ ) {
+            $end = $i + $n;
+            if ( $end > $total ) {
+                break;
+            }
+
+            $slice = array_slice( $tokens, $i, $n );
+            if ( empty( $slice ) ) {
+                continue;
+            }
+
+            $first = $slice[0];
+            $last  = $slice[ count( $slice ) - 1 ];
+
+            if ( in_array( $first, $stopwords, true ) || in_array( $last, $stopwords, true ) ) {
+                continue;
+            }
+
+            $phrase = implode( ' ', $slice );
+            if ( mb_strlen( $phrase, 'UTF-8' ) < 6 ) {
+                continue;
+            }
+
+            if ( ! isset( $ngrams[ $phrase ] ) ) {
+                $ngrams[ $phrase ] = 0;
+            }
+
+            $ngrams[ $phrase ]++;
+        }
+    }
+
+    if ( empty( $ngrams ) ) {
+        return [];
+    }
+
+    arsort( $ngrams );
+
+    return array_slice( $ngrams, 0, $k, true );
+}
+
+/**
+ * Computes Jaccard similarity between sets of keys.
+ *
+ * @param array $a First set (phrase => freq).
+ * @param array $b Second set.
+ * @return float
+ */
+function sai_lb_jaccard_keys( $a, $b ) {
+    if ( empty( $a ) || empty( $b ) ) {
+        return 0.0;
+    }
+
+    $keys_a = array_keys( $a );
+    $keys_b = array_keys( $b );
+
+    $intersect = array_intersect( $keys_a, $keys_b );
+    $union     = array_unique( array_merge( $keys_a, $keys_b ) );
+
+    if ( empty( $union ) ) {
+        return 0.0;
+    }
+
+    return count( $intersect ) / count( $union );
+}
+
+/**
+ * Generates canonical variants for scoring comparisons.
+ *
+ * @param string $canonical Canonical phrase.
+ * @return array
+ */
+function sai_lb_canonical_variants( $canonical ) {
+    $anchors        = new SAI_Anchors();
+    $canonical_norm = $anchors->normalize_text( $canonical );
+    $core_norm      = $anchors->normalize_text( $anchors->get_canonical_core( $canonical ) );
+
+    $variants = [];
+    if ( '' !== $canonical_norm ) {
+        $variants[] = $canonical_norm;
+    }
+    if ( '' !== $core_norm && $core_norm !== $canonical_norm ) {
+        $variants[] = $core_norm;
+    }
+
+    $base = '' !== $core_norm ? $core_norm : $canonical_norm;
+
+    $tokens = array_filter( preg_split( '/\s+/u', $base ) );
+    foreach ( $tokens as $token ) {
+        if ( '' === $token ) {
+            continue;
+        }
+        $variants[] = $token;
+
+        if ( preg_match( '/s$/u', $token ) ) {
+            $variants[] = preg_replace( '/s$/u', '', $token );
+        } else {
+            $variants[] = $token . 's';
+            $variants[] = $token . 'es';
+        }
+    }
+
+    return array_values( array_unique( array_filter( $variants ) ) );
+}
+
+/**
+ * Counts occurrences per 1000 words for canonical variants.
+ *
+ * @param string $plain Plain text.
+ * @param array  $variants Canonical variants.
+ * @return array Array with 'count' and 'density'.
+ */
+function sai_lb_canonical_density( $plain, $variants ) {
+    if ( '' === $plain || empty( $variants ) ) {
+        return [ 'count' => 0, 'density' => 0.0 ];
+    }
+
+    $normalized_body = sai_lb_normalize_for_vector( $plain );
+    if ( '' === $normalized_body ) {
+        return [ 'count' => 0, 'density' => 0.0 ];
+    }
+
+    $word_count = max( 1, str_word_count( $normalized_body ) );
+    $count      = 0;
+
+    foreach ( $variants as $variant ) {
+        if ( '' === $variant ) {
+            continue;
+        }
+
+        $pattern = '/\b' . preg_quote( $variant, '/' ) . '\b/u';
+        if ( preg_match_all( $pattern, $normalized_body, $matches ) ) {
+            $count += count( $matches[0] );
+        }
+    }
+
+    $density = ( $count / $word_count ) * 1000;
+
+    return [ 'count' => $count, 'density' => $density ];
+}
+
+/**
+ * Computes cannibalization score for a candidate against the mother page.
+ *
+ * @param int    $candidate_id Candidate post ID.
+ * @param int    $madre_id     Mother post ID.
+ * @param string $canonical    Canonical phrase.
+ * @return array
+ */
+function sai_lb_cannibal_score( $candidate_id, $madre_id, $canonical ) {
+    $candidate_id = absint( $candidate_id );
+    $madre_id     = absint( $madre_id );
+
+    if ( ! $candidate_id || ! $madre_id || $candidate_id === $madre_id ) {
+        return [ 'score' => 0, 'level' => 'amarillo', 'reasons' => [] ];
+    }
+
+    $variants = sai_lb_canonical_variants( $canonical );
+
+    $score   = 0;
+    $reasons = [];
+
+    // Title scoring.
+    $title       = get_the_title( $candidate_id );
+    $title_norm  = sai_lb_normalize_for_vector( $title );
+    $title_score = 0;
+    if ( '' !== $title_norm ) {
+        foreach ( $variants as $variant ) {
+            if ( '' === $variant ) {
+                continue;
+            }
+            if ( false !== mb_strpos( $title_norm, $variant, 0, 'UTF-8' ) ) {
+                if ( $variant === sai_lb_normalize_for_vector( $canonical ) ) {
+                    $title_score = max( $title_score, 30 );
+                    $reasons[]   = __( 'Título contiene el canónico completo', 'anchors-sin-ia' );
+                    break;
+                }
+                $title_score = max( $title_score, 20 );
+                $reasons[]   = __( 'Título contiene parte del canónico', 'anchors-sin-ia' );
+            }
+        }
+        if ( 0 === $title_score ) {
+            foreach ( $variants as $variant ) {
+                if ( '' === $variant ) {
+                    continue;
+                }
+                $tokens = explode( ' ', $variant );
+                foreach ( $tokens as $token ) {
+                    if ( '' !== $token && false !== mb_strpos( $title_norm, $token, 0, 'UTF-8' ) ) {
+                        $title_score = max( $title_score, 10 );
+                        $reasons[]   = __( 'Título comparte token del canónico', 'anchors-sin-ia' );
+                        break 2;
+                    }
+                }
+            }
+        }
+    }
+    $score += min( 30, $title_score );
+
+    // Slug scoring.
+    $slug      = get_post_field( 'post_name', $candidate_id );
+    $slug_norm = sai_lb_normalize_for_vector( str_replace( '-', ' ', $slug ) );
+    if ( '' !== $slug_norm ) {
+        foreach ( $variants as $variant ) {
+            if ( '' === $variant ) {
+                continue;
+            }
+            if ( false !== mb_strpos( $slug_norm, str_replace( ' ', '-', $variant ), 0, 'UTF-8' ) || false !== mb_strpos( $slug_norm, $variant, 0, 'UTF-8' ) ) {
+                $score    += 10;
+                $reasons[] = __( 'Slug coincide con el canónico', 'anchors-sin-ia' );
+                break;
+            }
+        }
+        if ( $score < 10 ) {
+            foreach ( $variants as $variant ) {
+                $tokens = explode( ' ', $variant );
+                foreach ( $tokens as $token ) {
+                    if ( '' !== $token && false !== mb_strpos( $slug_norm, $token, 0, 'UTF-8' ) ) {
+                        $score    += 5;
+                        $reasons[] = __( 'Slug comparte token del canónico', 'anchors-sin-ia' );
+                        break 2;
+                    }
+                }
+            }
+        }
+    }
+
+    $madre_analysis     = sai_lb_get_post_analysis( $madre_id );
+    $candidate_analysis = sai_lb_get_post_analysis( $candidate_id );
+
+    $similarity = sai_lb_cosine( $madre_analysis['vector'], $candidate_analysis['vector'] );
+    if ( $similarity >= 0.50 ) {
+        $score    += 40;
+        $reasons[] = sprintf( __( 'Similitud %.2f', 'anchors-sin-ia' ), $similarity );
+    } elseif ( $similarity >= 0.35 ) {
+        $score    += 25;
+        $reasons[] = sprintf( __( 'Similitud %.2f', 'anchors-sin-ia' ), $similarity );
+    } elseif ( $similarity >= 0.20 ) {
+        $score    += 10;
+        $reasons[] = sprintf( __( 'Similitud %.2f', 'anchors-sin-ia' ), $similarity );
+    }
+
+    $density = sai_lb_canonical_density( $candidate_analysis['plain'], $variants );
+    if ( $density['density'] >= 3 ) {
+        $score    += 10;
+        $reasons[] = __( 'Alta densidad del canónico', 'anchors-sin-ia' );
+    } elseif ( $density['density'] >= 1 ) {
+        $score    += 5;
+        $reasons[] = __( 'Densidad media del canónico', 'anchors-sin-ia' );
+    }
+
+    $jaccard = sai_lb_jaccard_keys( $madre_analysis['top_ngrams'], $candidate_analysis['top_ngrams'] );
+    if ( $jaccard >= 0.15 ) {
+        $score    += 10;
+        $reasons[] = __( 'N-grams compartidos con la madre', 'anchors-sin-ia' );
+    } elseif ( $jaccard >= 0.08 ) {
+        $score    += 5;
+        $reasons[] = __( 'Algunos n-grams compartidos', 'anchors-sin-ia' );
+    }
+
+    $score = min( 100, (int) round( $score ) );
+
+    if ( $score >= 70 ) {
+        $level = 'rojo';
+    } elseif ( $score >= 40 ) {
+        $level = 'naranja';
+    } elseif ( $score > 0 ) {
+        $level = 'amarillo';
+    } else {
+        $level = 'amarillo';
+    }
+
+    return [
+        'score'   => $score,
+        'level'   => $level,
+        'reasons' => array_values( array_unique( $reasons ) ),
+    ];
+}
+
+/**
+ * Assigns anchors to targets in round-robin fashion.
+ *
+ * @param array  $anchors   Anchors data.
+ * @param array  $targets   Target post IDs.
+ * @param string $from_url  Source URL.
+ * @param string $canonical Canonical fallback.
+ * @return array
+ */
+function sai_lb_round_robin_assign( $anchors, $targets, $from_url, $canonical ) {
+    $rows = [];
+
+    $targets = array_values( array_filter( array_map( 'absint', (array) $targets ) ) );
+    if ( empty( $targets ) || ! $from_url ) {
+        return $rows;
+    }
+
+    if ( empty( $anchors ) ) {
+        $anchors = [ [ 'text' => $canonical ] ];
+    }
+
+    $anchors = array_values( (array) $anchors );
+
+    $anchor_count  = count( $anchors );
+    $target_count  = count( $targets );
+    $max_iterations = max( $anchor_count, $target_count );
+
+    if ( $max_iterations <= 0 ) {
+        return $rows;
+    }
+
+    $fallback = $canonical;
+    if ( '' === $fallback ) {
+        $fallback = $from_url;
+    }
+
+    for ( $i = 0; $i < $max_iterations; $i++ ) {
+        $anchor = $anchors[ $i % $anchor_count ];
+        $text   = isset( $anchor['text'] ) && '' !== $anchor['text'] ? $anchor['text'] : $fallback;
+        $to_id  = $targets[ $i % $target_count ];
+        $to_url = get_permalink( $to_id );
+
+        if ( ! $to_url ) {
+            continue;
+        }
+
+        $rows[] = [
+            'from'        => $from_url,
+            'anchor_text' => $text,
+            'to'          => $to_url,
+        ];
+    }
+
+    return $rows;
+}
+
+/**
+ * Generates CSV export rows and summary.
+ *
+ * @param array $state Current state.
+ * @return array|WP_Error
+ */
+function sai_lb_generate_csv_data( $state ) {
+    $state      = wp_parse_args( (array) $state, sai_lb_default_state() );
+    $madre_id   = absint( $state['madre_id'] );
+    $canonical  = $state['canonical'];
+    $madre_url  = $madre_id ? get_permalink( $madre_id ) : '';
+    $hijas      = array_values( array_filter( array_map( 'absint', (array) $state['hijas_ids'] ) ) );
+    $nietas     = array_values( array_filter( array_map( 'absint', (array) $state['nietas_ids'] ) ) );
+    $rows       = [];
+    $madre_an   = is_array( $state['madre_anchors'] ) ? $state['madre_anchors'] : [];
+    $hijas_an   = is_array( $state['hijas_anchors'] ) ? $state['hijas_anchors'] : [];
+
+    if ( $madre_id && $madre_url && ! empty( $hijas ) ) {
+        $rows = array_merge( $rows, sai_lb_round_robin_assign( $madre_an, $hijas, $madre_url, $canonical ) );
+    }
+
+    if ( ! empty( $nietas ) && ! empty( $hijas ) ) {
+        foreach ( $hijas as $hija_id ) {
+            $from_url = get_permalink( $hija_id );
+            if ( ! $from_url ) {
+                continue;
+            }
+            $anchors_hija = isset( $hijas_an[ $hija_id ] ) ? $hijas_an[ $hija_id ] : [];
+            $rows         = array_merge( $rows, sai_lb_round_robin_assign( $anchors_hija, $nietas, $from_url, $canonical ) );
+        }
+    }
+
+    if ( empty( $rows ) ) {
+        return new WP_Error( 'sai_no_export', __( 'No hay datos suficientes para generar el CSV.', 'anchors-sin-ia' ), [ 'status' => 400 ] );
+    }
+
+    $output = fopen( 'php://temp', 'r+' );
+    fputcsv( $output, [ 'from_url', 'anchor_text', 'to_url' ] );
+    foreach ( $rows as $row ) {
+        fputcsv( $output, [ $row['from'], $row['anchor_text'], $row['to'] ] );
+    }
+    rewind( $output );
+    $csv = stream_get_contents( $output );
+    fclose( $output );
+
+    $anchors_hijas_total = 0;
+    if ( ! empty( $hijas_an ) ) {
+        foreach ( $hijas_an as $list ) {
+            if ( is_array( $list ) ) {
+                $anchors_hijas_total += count( $list );
+            }
+        }
+    }
+
+    return [
+        'csv'      => $csv,
+        'rows'     => $rows,
+        'filename' => 'linkbuilder-' . $madre_id . '.csv',
+        'summary'  => [
+            'madre'  => [
+                'id'      => $madre_id,
+                'anchors' => count( $madre_an ),
+            ],
+            'hijas'  => [
+                'count'   => count( $hijas ),
+                'anchors' => $anchors_hijas_total,
+            ],
+            'nietas' => [
+                'count' => count( $nietas ),
+            ],
+        ],
+    ];
+}

--- a/sai-plugin.php
+++ b/sai-plugin.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Plugin Name: Anchors sin IA
+ * Description: Herramienta para buscar entradas y extraer anchors sin IA.
+ * Version: 1.0.0
+ * Author: OpenAI
+ * Text Domain: anchors-sin-ia
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! defined( 'SAI_PLUGIN_FILE' ) ) {
+    define( 'SAI_PLUGIN_FILE', __FILE__ );
+}
+
+define( 'SAI_PLUGIN_DIR', plugin_dir_path( SAI_PLUGIN_FILE ) );
+define( 'SAI_PLUGIN_URL', plugin_dir_url( SAI_PLUGIN_FILE ) );
+
+require_once SAI_PLUGIN_DIR . 'includes/class-sai-anchors.php';
+require_once SAI_PLUGIN_DIR . 'includes/linkbuilder-helpers.php';
+require_once SAI_PLUGIN_DIR . 'includes/class-sai-rest.php';
+
+class Anchors_Sin_IA_Plugin {
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'register_admin_page' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        new SAI_REST_Controller();
+    }
+
+    /**
+     * Registers the admin page under Tools.
+     */
+    public function register_admin_page() {
+        add_management_page(
+            __( 'Anchors sin IA', 'anchors-sin-ia' ),
+            __( 'Anchors sin IA', 'anchors-sin-ia' ),
+            'edit_posts',
+            'anchors-sin-ia',
+            [ $this, 'render_admin_page' ]
+        );
+
+        add_management_page(
+            __( 'Linkbuilder sin IA', 'anchors-sin-ia' ),
+            __( 'Linkbuilder sin IA', 'anchors-sin-ia' ),
+            'edit_posts',
+            'sai-linkbuilder',
+            [ $this, 'render_linkbuilder_page' ]
+        );
+    }
+
+    /**
+     * Outputs the container for the admin app.
+     */
+    public function render_admin_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Anchors sin IA', 'anchors-sin-ia' ) . '</h1><div id="sai-app"></div></div>';
+    }
+
+    /**
+     * Outputs the container for the linkbuilder flow.
+     */
+    public function render_linkbuilder_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Linkbuilder sin IA', 'anchors-sin-ia' ) . '</h1><div id="sai-linkbuilder-app"></div></div>';
+    }
+
+    /**
+     * Enqueue assets only on plugin page.
+     *
+     * @param string $hook Current admin page hook.
+     */
+    public function enqueue_assets( $hook ) {
+        if ( 'tools_page_anchors-sin-ia' === $hook ) {
+            wp_enqueue_style(
+                'anchors-sin-ia-admin',
+                SAI_PLUGIN_URL . 'assets/admin.css',
+                [],
+                '1.0.0'
+            );
+
+            wp_enqueue_script(
+                'anchors-sin-ia-admin',
+                SAI_PLUGIN_URL . 'assets/admin.js',
+                [],
+                '1.0.0',
+                true
+            );
+
+            wp_localize_script(
+                'anchors-sin-ia-admin',
+                'AnchorsSinIA',
+                [
+                    'restUrl' => esc_url_raw( rest_url( 'anchors/v1/' ) ),
+                    'nonce'   => wp_create_nonce( 'wp_rest' ),
+                    'perPage' => 50,
+                    'i18n'    => [
+                        'search'         => __( 'Buscar', 'anchors-sin-ia' ),
+                        'view'           => __( 'Ver', 'anchors-sin-ia' ),
+                        'select'         => __( 'Seleccionar', 'anchors-sin-ia' ),
+                        'noResults'      => __( 'Sin resultados.', 'anchors-sin-ia' ),
+                        'copySuccess'    => __( 'Anchors copiados al portapapeles.', 'anchors-sin-ia' ),
+                        'copyError'      => __( 'No se pudo copiar. Copie manualmente.', 'anchors-sin-ia' ),
+                        'loading'        => __( 'Cargando...', 'anchors-sin-ia' ),
+                        'keywordLabel'   => __( 'Palabra clave (canónico)', 'anchors-sin-ia' ),
+                        'includeBody'    => __( 'Buscar también en el contenido', 'anchors-sin-ia' ),
+                        'wordCount'      => __( 'Palabras', 'anchors-sin-ia' ),
+                        'preset'         => __( 'Preset', 'anchors-sin-ia' ),
+                        'extractAnchors' => __( 'Extraer anchors', 'anchors-sin-ia' ),
+                        'copyAnchors'    => __( 'Copiar anchors', 'anchors-sin-ia' ),
+                        'tableHeader'    => [ __( 'Anchor', 'anchors-sin-ia' ), __( 'Clasificación', 'anchors-sin-ia' ), __( 'Frecuencia', 'anchors-sin-ia' ) ],
+                        'keywordRequired'=> __( 'Introduce una palabra clave.', 'anchors-sin-ia' ),
+                        'loadError'      => __( 'Ocurrió un error. Inténtalo nuevamente.', 'anchors-sin-ia' ),
+                        'noAnchors'      => __( 'No hay anchors disponibles.', 'anchors-sin-ia' ),
+                        'back'           => __( 'Volver a la búsqueda', 'anchors-sin-ia' ),
+                        'extracting'     => __( 'Extrayendo...', 'anchors-sin-ia' ),
+                        'pageLabel'      => __( 'Página', 'anchors-sin-ia' ),
+                        'usedQuotas'     => __( 'Cuotas usadas', 'anchors-sin-ia' ),
+                    ],
+                ]
+            );
+            return;
+        }
+
+        if ( 'tools_page_sai-linkbuilder' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'anchors-sin-ia-admin',
+            SAI_PLUGIN_URL . 'assets/admin.css',
+            [],
+            '1.0.0'
+        );
+
+        wp_enqueue_script(
+            'anchors-sin-ia-linkbuilder',
+            SAI_PLUGIN_URL . 'assets/linkbuilder.js',
+            [],
+            '1.0.0',
+            true
+        );
+
+        wp_localize_script(
+            'anchors-sin-ia-linkbuilder',
+            'AnchorsSinIALinkbuilder',
+            [
+                'restUrl' => esc_url_raw( rest_url( 'anchors/v1/' ) ),
+                'nonce'   => wp_create_nonce( 'wp_rest' ),
+                'perPage' => 50,
+                'i18n'    => [
+                    'search'            => __( 'Buscar', 'anchors-sin-ia' ),
+                    'includeBody'       => __( 'Buscar también en el contenido', 'anchors-sin-ia' ),
+                    'keywordLabel'      => __( 'Palabra clave (canónico)', 'anchors-sin-ia' ),
+                    'madreHeading'      => __( 'Paso 1: Selecciona la madre', 'anchors-sin-ia' ),
+                    'hijasHeading'      => __( 'Paso 2: Selecciona las hijas', 'anchors-sin-ia' ),
+                    'nietasHeading'     => __( 'Paso 3: Selecciona las nietas', 'anchors-sin-ia' ),
+                    'exportHeading'     => __( 'Paso 4: Exportar CSV', 'anchors-sin-ia' ),
+                    'next'              => __( 'Continuar', 'anchors-sin-ia' ),
+                    'saveMadre'         => __( 'Guardar madre y continuar', 'anchors-sin-ia' ),
+                    'saveHijas'         => __( 'Guardar hijas y continuar', 'anchors-sin-ia' ),
+                    'saveNietas'        => __( 'Guardar nietas y continuar', 'anchors-sin-ia' ),
+                    'reset'             => __( 'Reiniciar flujo', 'anchors-sin-ia' ),
+                    'loading'           => __( 'Cargando...', 'anchors-sin-ia' ),
+                    'noResults'         => __( 'Sin resultados.', 'anchors-sin-ia' ),
+                    'view'              => __( 'Ver', 'anchors-sin-ia' ),
+                    'select'            => __( 'Seleccionar', 'anchors-sin-ia' ),
+                    'selectionLimit'    => __( 'Límite de selección', 'anchors-sin-ia' ),
+                    'selected'          => __( 'Seleccionados', 'anchors-sin-ia' ),
+                    'canonical'         => __( 'Canónico', 'anchors-sin-ia' ),
+                    'madreAnchors'      => __( 'Anchors de la madre', 'anchors-sin-ia' ),
+                    'hijaAnchors'       => __( 'Anchors por hija', 'anchors-sin-ia' ),
+                    'wordCount'         => __( 'Palabras', 'anchors-sin-ia' ),
+                    'preset'            => __( 'Preset', 'anchors-sin-ia' ),
+                    'exportCsv'         => __( 'Exportar CSV', 'anchors-sin-ia' ),
+                    'exportSummary'     => __( 'Resumen de enlaces', 'anchors-sin-ia' ),
+                    'copyError'         => __( 'No se pudo completar la acción.', 'anchors-sin-ia' ),
+                    'step'              => __( 'Paso', 'anchors-sin-ia' ),
+                    'backToStep'        => __( 'Volver al paso', 'anchors-sin-ia' ),
+                    'cannibalHeading'   => __( 'Canibalización', 'anchors-sin-ia' ),
+                    'csvGenerated'      => __( 'CSV generado correctamente.', 'anchors-sin-ia' ),
+                    'limitExceeded'     => __( 'Has superado el límite de selección.', 'anchors-sin-ia' ),
+                    'missingMadre'      => __( 'Selecciona una madre antes de continuar.', 'anchors-sin-ia' ),
+                    'missingHijas'      => __( 'Selecciona al menos una hija.', 'anchors-sin-ia' ),
+                    'missingNietas'     => __( 'Selecciona al menos una nieta.', 'anchors-sin-ia' ),
+                    'exportError'       => __( 'No se pudo generar el CSV.', 'anchors-sin-ia' ),
+                ],
+            ]
+        );
+    }
+}
+
+new Anchors_Sin_IA_Plugin();


### PR DESCRIPTION
## Summary
- add a dedicated Linkbuilder admin screen that loads a new vanilla JS app to drive the four-step madre → hijas → nietas → CSV flow with pagination, limits, and export handling
- introduce PHP helpers for per-user Linkbuilder state, cached content analysis, cannibalization scoring, and round-robin CSV generation while wiring new REST endpoints and elastic search exclusions
- expose stopword and canonical helpers on the extractor and extend admin styling for the multi-step UI and cannibalization badges
- fix the madre selection flow by falling back to the current keyword as the canonical value when the field is left untouched
- extend anchor filtering to block conversational/CTA phrases via regex patterns and an expanded verb blacklist
- require anchors to intersect canonical tokens or base core terms so dynamic per-page cores cannot admit off-topic phrases

## Testing
- php -l sai-plugin.php
- php -l includes/class-sai-rest.php
- php -l includes/class-sai-anchors.php
- php -l includes/linkbuilder-helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68e5e118c390833286c640b44fa528ac